### PR TITLE
fix: Resolve critical profile component issues and enhance UX

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -54,7 +54,7 @@ const nextConfig = {
         headers: [
           {
             key: "Cross-Origin-Opener-Policy",
-            value: "same-origin-allow-popups",
+            value: "unsafe-none",
           },
         ],
       },

--- a/src/components/simple-editor/DevicePreview.tsx
+++ b/src/components/simple-editor/DevicePreview.tsx
@@ -3,6 +3,8 @@
 import React, { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Smartphone, Monitor, X } from 'lucide-react';
+import { SimpleRenderer } from '@/components/profile/SimpleRenderer';
+import type { ProfileComponent } from './utils/dataStructure';
 
 export type DeviceType = 'mobile' | 'desktop';
 
@@ -30,10 +32,12 @@ const DEVICE_CONFIGS: Record<DeviceType, DeviceConfig> = {
 
 interface DevicePreviewProps {
   profileUrl: string;
+  components: ProfileComponent[];
+  background?: any;
   onClose: () => void;
 }
 
-export function DevicePreview({ profileUrl, onClose }: DevicePreviewProps) {
+export function DevicePreview({ profileUrl, components, background, onClose }: DevicePreviewProps) {
   const [selectedDevice, setSelectedDevice] = useState<DeviceType>('mobile');
   const config = DEVICE_CONFIGS[selectedDevice];
 
@@ -93,15 +97,18 @@ export function DevicePreview({ profileUrl, onClose }: DevicePreviewProps) {
                 </div>
               )}
 
-              {/* iframe でプロフィールページを表示 */}
-              <iframe
-                src={profileUrl}
-                className="w-full h-full border-0"
+              {/* SimpleRenderer で編集中のデータを表示 */}
+              <div
+                className="w-full h-full overflow-auto"
                 style={{
                   height: selectedDevice !== 'desktop' ? 'calc(100% - 24px)' : '100%'
                 }}
-                title="Profile Preview"
-              />
+              >
+                <SimpleRenderer
+                  components={components}
+                  background={background}
+                />
+              </div>
             </div>
 
             {/* デバイス情報 */}

--- a/src/components/simple-editor/utils/validation.ts
+++ b/src/components/simple-editor/utils/validation.ts
@@ -58,7 +58,7 @@ export const ProfileContentSchema = z.object({
   bio: z.string().max(1000).transform(sanitizeString).optional(),
   photoURL: z.string().refine((val) => val === '' || z.string().url().safeParse(val).success, 'Invalid URL').optional(),
   cardBackgroundColor: z.string().regex(/^#[0-9A-Fa-f]{6}$/).optional(),
-  cardBackgroundOpacity: z.number().min(0).max(1).optional(),
+  cardBackgroundOpacity: z.number().min(0).max(100).optional(),
 });
 
 // Component content schema (union of all content types)
@@ -126,7 +126,8 @@ export function validateComponentContent(type: string, content: unknown): boolea
       default:
         return false;
     }
-  } catch {
+  } catch (error) {
+    console.error(`[Validation] Error validating ${type} content:`, error);
     return false;
   }
 }
@@ -155,7 +156,8 @@ export function sanitizeComponentContent(type: string, content: unknown): unknow
       default:
         return content;
     }
-  } catch {
+  } catch (error) {
+    console.error(`[Sanitization] Error sanitizing ${type} content:`, error);
     return null;
   }
 }


### PR DESCRIPTION
## 🚀 重要なバグ修正とUX改善

### ✅ 修正した問題

#### 1. プロファイルコンポーネント保存バグ
- **問題**: `cardBackgroundOpacity` バリデーションが 0-1 範囲を期待していたが、UIは 0-100 を送信
- **修正**: バリデーションスキーマを `max(100)` に変更、デフォルト値も統一

#### 2. 編集画面での表示問題  
- **問題**: プロファイルコンポーネントの内容が編集画面で正しく表示されない
- **修正**: 複雑な表示ロジックをシンプルな `switch` 文に書き換え

#### 3. プレビュー機能の問題
- **問題**: `iframe` ベースのプレビューで編集中データが反映されない
- **修正**: `SimpleRenderer` を直接使用するリアルタイムプレビューに変更

#### 4. Google サインイン問題
- **問題**: `Cross-Origin-Opener-Policy` によるポップアップブロック
- **修正**: ポリシーを `"unsafe-none"` に変更

### 🧪 テスト済み機能

- ✅ プロファイルコンポーネントの編集・保存
- ✅ 日本語データでの動作確認
- ✅ リアルタイムプレビュー機能
- ✅ 各コンポーネントタイプの表示

### 📝 技術的詳細

**変更ファイル:**
- `next.config.js`: Cross-Origin-Opener-Policy 修正
- `SimplePageEditor.tsx`: 表示ロジック改善とプレビュー統合
- `DevicePreview.tsx`: iframe から直接レンダリングに変更
- `validation.ts`: バリデーション範囲修正

**互換性:**
- 既存データとの後方互換性を維持
- デプロイ時の追加設定不要

### 🎯 本番環境での確認事項

- [ ] プロファイル編集の保存動作
- [ ] プレビュー機能の動作
- [ ] Google サインインの動作
- [ ] 既存ユーザーデータの表示

🚀 Generated with [Claude Code](https://claude.ai/code)