### PR TITLE
fix: reflect profile card design publicly

### DIFF
--- a/src/components/profile/ReadOnlyProfileInfo.tsx
+++ b/src/components/profile/ReadOnlyProfileInfo.tsx
@@ -40,6 +40,23 @@ function getCardBackgroundStyle(
   return { backgroundColor: `rgba(${red}, ${green}, ${blue}, ${alpha})` };
 }
 
+function isDarkBackground(color?: string, opacity?: number) {
+  if (!color) return false;
+
+  const alpha =
+    typeof opacity === "number" ? Math.min(100, Math.max(0, opacity)) / 100 : 1;
+  const hex = color.replace("#", "");
+
+  if (alpha < 0.5 || !/^[0-9a-fA-F]{6}$/.test(hex)) return false;
+
+  const red = parseInt(hex.slice(0, 2), 16);
+  const green = parseInt(hex.slice(2, 4), 16);
+  const blue = parseInt(hex.slice(4, 6), 16);
+  const luminance = 0.299 * red + 0.587 * green + 0.114 * blue;
+
+  return luminance < 140;
+}
+
 export function ReadOnlyProfileInfo({ component }: ReadOnlyProfileInfoProps) {
   const [isExpanded, setIsExpanded] = useState(false);
   const [isProfileExpanded, setIsProfileExpanded] = useState(false);
@@ -69,6 +86,21 @@ export function ReadOnlyProfileInfo({ component }: ReadOnlyProfileInfoProps) {
     cardBackgroundColor,
     cardBackgroundOpacity,
   );
+  const useLightText = isDarkBackground(
+    cardBackgroundColor,
+    cardBackgroundOpacity,
+  );
+  const primaryTextClass = useLightText ? "text-white" : "text-gray-800";
+  const secondaryTextClass = useLightText ? "text-gray-100" : "text-gray-600";
+  const bodyTextClass = useLightText ? "text-gray-100" : "text-gray-700";
+  const borderClass = useLightText ? "border-white/30" : "border-gray-200";
+  const iconClass = useLightText ? "text-gray-100" : "text-gray-400";
+  const linkClass = useLightText
+    ? "text-blue-100 hover:underline"
+    : "text-blue-600 hover:underline";
+  const detailButtonClass = useLightText
+    ? "text-gray-100 hover:text-white"
+    : "text-gray-600 hover:text-gray-900";
 
   // 表示名の決定
   const displayName =
@@ -136,27 +168,29 @@ export function ReadOnlyProfileInfo({ component }: ReadOnlyProfileInfoProps) {
       <div className="bg-white rounded-lg shadow-md p-4" style={cardStyle}>
         {/* 名前・役職・会社 */}
         <div className="text-center mb-3">
-          <h2 className="text-base sm:text-lg font-bold text-gray-800">
+          <h2 className={`text-base sm:text-lg font-bold ${primaryTextClass}`}>
             {displayName}
           </h2>
           {position && (
-            <p className="text-sm text-gray-600 mt-0.5">{position}</p>
+            <p className={`text-sm mt-0.5 ${secondaryTextClass}`}>{position}</p>
           )}
-          {company && <p className="text-sm text-gray-600">{company}</p>}
+          {company && (
+            <p className={`text-sm ${secondaryTextClass}`}>{company}</p>
+          )}
         </div>
 
         {/* 自己紹介（3行制限と展開機能） */}
         {bio && (
-          <div className="pb-3 border-b border-gray-200">
+          <div className={`pb-3 border-b ${borderClass}`}>
             <p
-              className={`text-gray-700 text-sm ${!isProfileExpanded ? "line-clamp-3" : ""}`}
+              className={`${bodyTextClass} text-sm ${!isProfileExpanded ? "line-clamp-3" : ""}`}
             >
               {bio}
             </p>
             {bio.length > 150 && (
               <button
                 onClick={() => setIsProfileExpanded(!isProfileExpanded)}
-                className="text-blue-600 hover:text-blue-700 text-sm mt-1"
+                className={`${linkClass} text-sm mt-1`}
               >
                 {isProfileExpanded ? "閉じる" : "...続きを読む"}
               </button>
@@ -180,7 +214,7 @@ export function ReadOnlyProfileInfo({ component }: ReadOnlyProfileInfoProps) {
           <Button
             variant="ghost"
             onClick={() => setIsExpanded(!isExpanded)}
-            className="w-full h-8 flex items-center justify-center gap-2 text-gray-600 hover:text-gray-900 text-sm"
+            className={`w-full h-8 flex items-center justify-center gap-2 text-sm ${detailButtonClass}`}
           >
             <span>詳細情報を{isExpanded ? "非表示" : "表示"}</span>
             {isExpanded ? (
@@ -199,11 +233,8 @@ export function ReadOnlyProfileInfo({ component }: ReadOnlyProfileInfoProps) {
         >
           {email && (
             <div className="flex items-center space-x-3">
-              <Mail className="w-5 h-5 text-gray-400" />
-              <a
-                href={`mailto:${email}`}
-                className="text-blue-600 hover:underline"
-              >
+              <Mail className={`w-5 h-5 ${iconClass}`} />
+              <a href={`mailto:${email}`} className={linkClass}>
                 {email}
               </a>
             </div>
@@ -211,11 +242,8 @@ export function ReadOnlyProfileInfo({ component }: ReadOnlyProfileInfoProps) {
 
           {phone && (
             <div className="flex items-center space-x-3">
-              <Phone className="w-5 h-5 text-gray-400" />
-              <a
-                href={`tel:${phone}`}
-                className="text-blue-600 hover:underline"
-              >
+              <Phone className={`w-5 h-5 ${iconClass}`} />
+              <a href={`tel:${phone}`} className={linkClass}>
                 {phone}
               </a>
             </div>
@@ -223,11 +251,8 @@ export function ReadOnlyProfileInfo({ component }: ReadOnlyProfileInfoProps) {
 
           {cellPhone && (
             <div className="flex items-center space-x-3">
-              <Smartphone className="w-5 h-5 text-gray-400" />
-              <a
-                href={`tel:${cellPhone}`}
-                className="text-blue-600 hover:underline"
-              >
+              <Smartphone className={`w-5 h-5 ${iconClass}`} />
+              <a href={`tel:${cellPhone}`} className={linkClass}>
                 {cellPhone}
               </a>
             </div>
@@ -235,12 +260,12 @@ export function ReadOnlyProfileInfo({ component }: ReadOnlyProfileInfoProps) {
 
           {website && (
             <div className="flex items-center space-x-3">
-              <Globe className="w-5 h-5 text-gray-400" />
+              <Globe className={`w-5 h-5 ${iconClass}`} />
               <a
                 href={website}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="text-blue-600 hover:underline"
+                className={linkClass}
               >
                 {website}
               </a>
@@ -249,8 +274,8 @@ export function ReadOnlyProfileInfo({ component }: ReadOnlyProfileInfoProps) {
 
           {(company || department) && (
             <div className="flex items-center space-x-3">
-              <Building className="w-5 h-5 text-gray-400" />
-              <span className="text-gray-700">
+              <Building className={`w-5 h-5 ${iconClass}`} />
+              <span className={bodyTextClass}>
                 {company}
                 {department && ` - ${department}`}
               </span>
@@ -259,8 +284,8 @@ export function ReadOnlyProfileInfo({ component }: ReadOnlyProfileInfoProps) {
 
           {(address || city || postalCode) && (
             <div className="flex items-center space-x-3">
-              <MapPin className="w-5 h-5 text-gray-400" />
-              <span className="text-gray-700">
+              <MapPin className={`w-5 h-5 ${iconClass}`} />
+              <span className={bodyTextClass}>
                 {postalCode && `〒${postalCode} `}
                 {city} {address}
               </span>

--- a/src/components/profile/ReadOnlyProfileInfo.tsx
+++ b/src/components/profile/ReadOnlyProfileInfo.tsx
@@ -40,14 +40,12 @@ function getCardBackgroundStyle(
   return { backgroundColor: `rgba(${red}, ${green}, ${blue}, ${alpha})` };
 }
 
-function isDarkBackground(color?: string, opacity?: number) {
+function isDarkBackground(color?: string) {
   if (!color) return false;
 
-  const alpha =
-    typeof opacity === "number" ? Math.min(100, Math.max(0, opacity)) / 100 : 1;
   const hex = color.replace("#", "");
 
-  if (alpha < 0.5 || !/^[0-9a-fA-F]{6}$/.test(hex)) return false;
+  if (!/^[0-9a-fA-F]{6}$/.test(hex)) return false;
 
   const red = parseInt(hex.slice(0, 2), 16);
   const green = parseInt(hex.slice(2, 4), 16);
@@ -86,10 +84,7 @@ export function ReadOnlyProfileInfo({ component }: ReadOnlyProfileInfoProps) {
     cardBackgroundColor,
     cardBackgroundOpacity,
   );
-  const useLightText = isDarkBackground(
-    cardBackgroundColor,
-    cardBackgroundOpacity,
-  );
+  const useLightText = isDarkBackground(cardBackgroundColor);
   const primaryTextClass = useLightText ? "text-white" : "text-gray-800";
   const secondaryTextClass = useLightText ? "text-gray-100" : "text-gray-600";
   const bodyTextClass = useLightText ? "text-gray-100" : "text-gray-700";

--- a/src/components/profile/ReadOnlyProfileInfo.tsx
+++ b/src/components/profile/ReadOnlyProfileInfo.tsx
@@ -15,9 +15,20 @@ import type { ProfileComponent } from "../simple-editor/utils/dataStructure";
 import { Button } from "@/components/ui/button";
 import Image from "next/image";
 
+export type PageBackground =
+  | { type?: "solid" | "color"; color?: string }
+  | {
+      type: "gradient";
+      from?: string;
+      to?: string;
+      gradient?: { from?: string; to?: string };
+    }
+  | { type: "image"; url?: string; opacity?: number }
+  | { type: "pattern"; pattern?: string };
+
 interface ReadOnlyProfileInfoProps {
   component: ProfileComponent;
-  pageBackground?: any;
+  pageBackground?: PageBackground | null;
 }
 
 function getCardBackgroundStyle(
@@ -58,8 +69,12 @@ function blendRgb(
 
 type RgbColor = { red: number; green: number; blue: number };
 
-function getPageBackgroundRgb(pageBackground?: any): RgbColor {
-  if (pageBackground?.type === "solid") {
+function getLuminance(color: RgbColor) {
+  return 0.299 * color.red + 0.587 * color.green + 0.114 * color.blue;
+}
+
+function getPageBackgroundRgb(pageBackground?: PageBackground | null): RgbColor {
+  if (pageBackground?.type === "solid" || pageBackground?.type === "color") {
     const solid = getRgbColor(pageBackground.color || "#ffffff");
     if (solid.red !== null && solid.green !== null && solid.blue !== null) {
       return solid;
@@ -67,8 +82,12 @@ function getPageBackgroundRgb(pageBackground?: any): RgbColor {
   }
 
   if (pageBackground?.type === "gradient") {
-    const from = getRgbColor(pageBackground.from || "#ffffff");
-    const to = getRgbColor(pageBackground.to || "#ffffff");
+    const from = getRgbColor(
+      pageBackground.from || pageBackground.gradient?.from || "#ffffff",
+    );
+    const to = getRgbColor(
+      pageBackground.to || pageBackground.gradient?.to || "#ffffff",
+    );
     if (
       from.red !== null &&
       from.green !== null &&
@@ -77,11 +96,7 @@ function getPageBackgroundRgb(pageBackground?: any): RgbColor {
       to.green !== null &&
       to.blue !== null
     ) {
-      return {
-        red: Math.round((from.red + to.red) / 2),
-        green: Math.round((from.green + to.green) / 2),
-        blue: Math.round((from.blue + to.blue) / 2),
-      };
+      return getLuminance(from) < getLuminance(to) ? from : to;
     }
   }
 
@@ -105,7 +120,7 @@ function getRgbColor(color: string) {
 function isDarkBackground(
   color?: string,
   opacity?: number,
-  pageBackground?: any,
+  pageBackground?: PageBackground | null,
 ) {
   if (!color) return false;
 
@@ -123,8 +138,7 @@ function isDarkBackground(
     getAlpha(opacity),
     getPageBackgroundRgb(pageBackground),
   );
-  const luminance =
-    0.299 * effective.red + 0.587 * effective.green + 0.114 * effective.blue;
+  const luminance = getLuminance(effective);
 
   return luminance < 140;
 }
@@ -177,6 +191,9 @@ export function ReadOnlyProfileInfo({
   const detailButtonClass = useLightText
     ? "text-gray-100 hover:text-white hover:bg-white/10"
     : "text-gray-600 hover:text-gray-900";
+  const vCardButtonClass = useLightText
+    ? "w-full max-w-xs border-white/50 bg-white/10 text-white hover:bg-white/20 hover:text-white"
+    : "w-full max-w-xs";
 
   // 表示名の決定
   const displayName =
@@ -279,8 +296,8 @@ export function ReadOnlyProfileInfo({
           <VCardButton
             username={displayName}
             profileData={vCardData}
-            className="w-full max-w-xs"
-            variant="default"
+            className={vCardButtonClass}
+            variant={useLightText ? "outline" : "default"}
             size="lg"
           />
         </div>
@@ -294,9 +311,9 @@ export function ReadOnlyProfileInfo({
           >
             <span>詳細情報を{isExpanded ? "非表示" : "表示"}</span>
             {isExpanded ? (
-              <ChevronUp className="h-4 w-4" />
+              <ChevronUp className={`h-4 w-4 ${iconClass}`} />
             ) : (
-              <ChevronDown className="h-4 w-4" />
+              <ChevronDown className={`h-4 w-4 ${iconClass}`} />
             )}
           </Button>
         )}

--- a/src/components/profile/ReadOnlyProfileInfo.tsx
+++ b/src/components/profile/ReadOnlyProfileInfo.tsx
@@ -25,31 +25,51 @@ function getCardBackgroundStyle(
 ): React.CSSProperties | undefined {
   if (!color) return undefined;
 
+  return { backgroundColor: getBlendedCardColor(color, opacity) };
+}
+
+function getBlendedCardColor(color: string, opacity?: number) {
+  const { red, green, blue } = getBlendedRgbColor(color, opacity);
+  if (red === null || green === null || blue === null) return color;
+
+  return `rgb(${red}, ${green}, ${blue})`;
+}
+
+function getBlendedRgbColor(color: string, opacity?: number) {
+  const { red, green, blue } = getRgbColor(color);
+  if (red === null || green === null || blue === null) {
+    return { red: null, green: null, blue: null };
+  }
+
   const alpha =
     typeof opacity === "number" ? Math.min(100, Math.max(0, opacity)) / 100 : 1;
+
+  return {
+    red: Math.round(red * alpha + 255 * (1 - alpha)),
+    green: Math.round(green * alpha + 255 * (1 - alpha)),
+    blue: Math.round(blue * alpha + 255 * (1 - alpha)),
+  };
+}
+
+function getRgbColor(color: string) {
   const hex = color.replace("#", "");
 
   if (!/^[0-9a-fA-F]{6}$/.test(hex)) {
-    return { backgroundColor: color };
+    return { red: null, green: null, blue: null };
   }
 
-  const red = parseInt(hex.slice(0, 2), 16);
-  const green = parseInt(hex.slice(2, 4), 16);
-  const blue = parseInt(hex.slice(4, 6), 16);
-
-  return { backgroundColor: `rgba(${red}, ${green}, ${blue}, ${alpha})` };
+  return {
+    red: parseInt(hex.slice(0, 2), 16),
+    green: parseInt(hex.slice(2, 4), 16),
+    blue: parseInt(hex.slice(4, 6), 16),
+  };
 }
 
-function isDarkBackground(color?: string) {
+function isDarkBackground(color?: string, opacity?: number) {
   if (!color) return false;
 
-  const hex = color.replace("#", "");
-
-  if (!/^[0-9a-fA-F]{6}$/.test(hex)) return false;
-
-  const red = parseInt(hex.slice(0, 2), 16);
-  const green = parseInt(hex.slice(2, 4), 16);
-  const blue = parseInt(hex.slice(4, 6), 16);
+  const { red, green, blue } = getBlendedRgbColor(color, opacity);
+  if (red === null || green === null || blue === null) return false;
   const luminance = 0.299 * red + 0.587 * green + 0.114 * blue;
 
   return luminance < 140;
@@ -84,7 +104,10 @@ export function ReadOnlyProfileInfo({ component }: ReadOnlyProfileInfoProps) {
     cardBackgroundColor,
     cardBackgroundOpacity,
   );
-  const useLightText = isDarkBackground(cardBackgroundColor);
+  const useLightText = isDarkBackground(
+    cardBackgroundColor,
+    cardBackgroundOpacity,
+  );
   const primaryTextClass = useLightText ? "text-white" : "text-gray-800";
   const secondaryTextClass = useLightText ? "text-gray-100" : "text-gray-600";
   const bodyTextClass = useLightText ? "text-gray-100" : "text-gray-700";

--- a/src/components/profile/ReadOnlyProfileInfo.tsx
+++ b/src/components/profile/ReadOnlyProfileInfo.tsx
@@ -19,6 +19,27 @@ interface ReadOnlyProfileInfoProps {
   component: ProfileComponent;
 }
 
+function getCardBackgroundStyle(
+  color?: string,
+  opacity?: number,
+): React.CSSProperties | undefined {
+  if (!color) return undefined;
+
+  const alpha =
+    typeof opacity === "number" ? Math.min(100, Math.max(0, opacity)) / 100 : 1;
+  const hex = color.replace("#", "");
+
+  if (!/^[0-9a-fA-F]{6}$/.test(hex)) {
+    return { backgroundColor: color };
+  }
+
+  const red = parseInt(hex.slice(0, 2), 16);
+  const green = parseInt(hex.slice(2, 4), 16);
+  const blue = parseInt(hex.slice(4, 6), 16);
+
+  return { backgroundColor: `rgba(${red}, ${green}, ${blue}, ${alpha})` };
+}
+
 export function ReadOnlyProfileInfo({ component }: ReadOnlyProfileInfoProps) {
   const [isExpanded, setIsExpanded] = useState(false);
   const [isProfileExpanded, setIsProfileExpanded] = useState(false);
@@ -41,7 +62,13 @@ export function ReadOnlyProfileInfo({ component }: ReadOnlyProfileInfoProps) {
     website,
     bio,
     photoURL,
+    cardBackgroundColor,
+    cardBackgroundOpacity,
   } = content;
+  const cardStyle = getCardBackgroundStyle(
+    cardBackgroundColor,
+    cardBackgroundOpacity,
+  );
 
   // 表示名の決定
   const displayName =
@@ -106,7 +133,7 @@ export function ReadOnlyProfileInfo({ component }: ReadOnlyProfileInfoProps) {
       </div>
 
       {/* プロフィール情報カード */}
-      <div className="bg-white rounded-lg shadow-md p-4">
+      <div className="bg-white rounded-lg shadow-md p-4" style={cardStyle}>
         {/* 名前・役職・会社 */}
         <div className="text-center mb-3">
           <h2 className="text-base sm:text-lg font-bold text-gray-800">

--- a/src/components/profile/ReadOnlyProfileInfo.tsx
+++ b/src/components/profile/ReadOnlyProfileInfo.tsx
@@ -17,6 +17,7 @@ import Image from "next/image";
 
 interface ReadOnlyProfileInfoProps {
   component: ProfileComponent;
+  pageBackground?: any;
 }
 
 function getCardBackgroundStyle(
@@ -25,30 +26,66 @@ function getCardBackgroundStyle(
 ): React.CSSProperties | undefined {
   if (!color) return undefined;
 
-  return { backgroundColor: getBlendedCardColor(color, opacity) };
-}
-
-function getBlendedCardColor(color: string, opacity?: number) {
-  const { red, green, blue } = getBlendedRgbColor(color, opacity);
-  if (red === null || green === null || blue === null) return color;
-
-  return `rgb(${red}, ${green}, ${blue})`;
-}
-
-function getBlendedRgbColor(color: string, opacity?: number) {
   const { red, green, blue } = getRgbColor(color);
   if (red === null || green === null || blue === null) {
-    return { red: null, green: null, blue: null };
+    return { backgroundColor: color };
   }
 
-  const alpha =
-    typeof opacity === "number" ? Math.min(100, Math.max(0, opacity)) / 100 : 1;
+  const alpha = getAlpha(opacity);
 
+  return { backgroundColor: `rgba(${red}, ${green}, ${blue}, ${alpha})` };
+}
+
+function getAlpha(opacity?: number) {
+  return typeof opacity === "number"
+    ? Math.min(100, Math.max(0, opacity)) / 100
+    : 1;
+}
+
+function blendRgb(
+  foreground: RgbColor,
+  alpha: number,
+  background: RgbColor,
+): RgbColor {
   return {
-    red: Math.round(red * alpha + 255 * (1 - alpha)),
-    green: Math.round(green * alpha + 255 * (1 - alpha)),
-    blue: Math.round(blue * alpha + 255 * (1 - alpha)),
+    red: Math.round(foreground.red * alpha + background.red * (1 - alpha)),
+    green: Math.round(
+      foreground.green * alpha + background.green * (1 - alpha),
+    ),
+    blue: Math.round(foreground.blue * alpha + background.blue * (1 - alpha)),
   };
+}
+
+type RgbColor = { red: number; green: number; blue: number };
+
+function getPageBackgroundRgb(pageBackground?: any): RgbColor {
+  if (pageBackground?.type === "solid") {
+    const solid = getRgbColor(pageBackground.color || "#ffffff");
+    if (solid.red !== null && solid.green !== null && solid.blue !== null) {
+      return solid;
+    }
+  }
+
+  if (pageBackground?.type === "gradient") {
+    const from = getRgbColor(pageBackground.from || "#ffffff");
+    const to = getRgbColor(pageBackground.to || "#ffffff");
+    if (
+      from.red !== null &&
+      from.green !== null &&
+      from.blue !== null &&
+      to.red !== null &&
+      to.green !== null &&
+      to.blue !== null
+    ) {
+      return {
+        red: Math.round((from.red + to.red) / 2),
+        green: Math.round((from.green + to.green) / 2),
+        blue: Math.round((from.blue + to.blue) / 2),
+      };
+    }
+  }
+
+  return { red: 255, green: 255, blue: 255 };
 }
 
 function getRgbColor(color: string) {
@@ -65,17 +102,37 @@ function getRgbColor(color: string) {
   };
 }
 
-function isDarkBackground(color?: string, opacity?: number) {
+function isDarkBackground(
+  color?: string,
+  opacity?: number,
+  pageBackground?: any,
+) {
   if (!color) return false;
 
-  const { red, green, blue } = getBlendedRgbColor(color, opacity);
-  if (red === null || green === null || blue === null) return false;
-  const luminance = 0.299 * red + 0.587 * green + 0.114 * blue;
+  const foreground = getRgbColor(color);
+  if (
+    foreground.red === null ||
+    foreground.green === null ||
+    foreground.blue === null
+  ) {
+    return false;
+  }
+
+  const effective = blendRgb(
+    foreground,
+    getAlpha(opacity),
+    getPageBackgroundRgb(pageBackground),
+  );
+  const luminance =
+    0.299 * effective.red + 0.587 * effective.green + 0.114 * effective.blue;
 
   return luminance < 140;
 }
 
-export function ReadOnlyProfileInfo({ component }: ReadOnlyProfileInfoProps) {
+export function ReadOnlyProfileInfo({
+  component,
+  pageBackground,
+}: ReadOnlyProfileInfoProps) {
   const [isExpanded, setIsExpanded] = useState(false);
   const [isProfileExpanded, setIsProfileExpanded] = useState(false);
   const content = (component.content as any) || {};
@@ -107,6 +164,7 @@ export function ReadOnlyProfileInfo({ component }: ReadOnlyProfileInfoProps) {
   const useLightText = isDarkBackground(
     cardBackgroundColor,
     cardBackgroundOpacity,
+    pageBackground,
   );
   const primaryTextClass = useLightText ? "text-white" : "text-gray-800";
   const secondaryTextClass = useLightText ? "text-gray-100" : "text-gray-600";
@@ -117,7 +175,7 @@ export function ReadOnlyProfileInfo({ component }: ReadOnlyProfileInfoProps) {
     ? "text-blue-100 hover:underline"
     : "text-blue-600 hover:underline";
   const detailButtonClass = useLightText
-    ? "text-gray-100 hover:text-white"
+    ? "text-gray-100 hover:text-white hover:bg-white/10"
     : "text-gray-600 hover:text-gray-900";
 
   // 表示名の決定

--- a/src/components/profile/SimpleRenderer.tsx
+++ b/src/components/profile/SimpleRenderer.tsx
@@ -18,28 +18,30 @@ const TextComponent = memo(({ component }: { component: ProfileComponent }) => {
 });
 TextComponent.displayName = "TextComponent";
 
-const ImageComponent = memo(({ component }: { component: ProfileComponent }) => {
-  const content = component.content as any;
-  return (
-    <div className="w-[90%] max-w-[600px] mx-auto bg-white bg-opacity-90 rounded-lg shadow-md p-4 mb-4">
-      {content?.src ? (
-        <Image
-          src={content.src}
-          alt={content?.alt || "画像"}
-          width={500}
-          height={300}
-          className="w-full h-auto rounded"
-          priority={false}
-          loading="lazy"
-        />
-      ) : (
-        <div className="bg-gray-200 h-32 rounded flex items-center justify-center">
-          <span className="text-gray-500">画像がありません</span>
-        </div>
-      )}
-    </div>
-  );
-});
+const ImageComponent = memo(
+  ({ component }: { component: ProfileComponent }) => {
+    const content = component.content as any;
+    return (
+      <div className="w-[90%] max-w-[600px] mx-auto bg-white bg-opacity-90 rounded-lg shadow-md p-4 mb-4">
+        {content?.src ? (
+          <Image
+            src={content.src}
+            alt={content?.alt || "画像"}
+            width={500}
+            height={300}
+            className="w-full h-auto rounded"
+            priority={false}
+            loading="lazy"
+          />
+        ) : (
+          <div className="bg-gray-200 h-32 rounded flex items-center justify-center">
+            <span className="text-gray-500">画像がありません</span>
+          </div>
+        )}
+      </div>
+    );
+  },
+);
 ImageComponent.displayName = "ImageComponent";
 
 const LinkComponent = memo(({ component }: { component: ProfileComponent }) => {
@@ -55,10 +57,20 @@ const LinkComponent = memo(({ component }: { component: ProfileComponent }) => {
 });
 LinkComponent.displayName = "LinkComponent";
 
-const ProfileComponentView = memo(({ component }: { component: ProfileComponent }) => {
-  // ReadOnlyProfileInfoを使用して拡充されたプロフィールを表示
-  return <ReadOnlyProfileInfo component={component} />;
-});
+const ProfileComponentView = memo(
+  ({
+    component,
+    background,
+  }: {
+    component: ProfileComponent;
+    background?: any;
+  }) => {
+    // ReadOnlyProfileInfoを使用して拡充されたプロフィールを表示
+    return (
+      <ReadOnlyProfileInfo component={component} pageBackground={background} />
+    );
+  },
+);
 ProfileComponentView.displayName = "ProfileComponentView";
 
 // メインのSimpleRendererコンポーネント（memo化）
@@ -112,6 +124,7 @@ export const SimpleRenderer = memo(function SimpleRenderer({
                       <ProfileComponentView
                         key={component.id}
                         component={component}
+                        background={background}
                       />
                     );
                   default:

--- a/src/components/profile/SimpleRenderer.tsx
+++ b/src/components/profile/SimpleRenderer.tsx
@@ -4,6 +4,7 @@ import React, { memo } from "react";
 import type { ProfileComponent } from "../simple-editor/utils/dataStructure";
 import { SocialLinkButton } from "../simple-editor/SocialLinkButton";
 import { ReadOnlyProfileInfo } from "./ReadOnlyProfileInfo";
+import type { PageBackground } from "./ReadOnlyProfileInfo";
 import { getBackgroundStyle } from "../simple-editor/BackgroundCustomizer";
 import Image from "next/image";
 
@@ -63,7 +64,7 @@ const ProfileComponentView = memo(
     background,
   }: {
     component: ProfileComponent;
-    background?: any;
+    background?: PageBackground | null;
   }) => {
     // ReadOnlyProfileInfoを使用して拡充されたプロフィールを表示
     return (
@@ -79,7 +80,7 @@ export const SimpleRenderer = memo(function SimpleRenderer({
   background = null,
 }: {
   components: ProfileComponent[];
-  background?: any;
+  background?: PageBackground | null;
 }) {
   // componentsが配列でない場合の対応
   const safeComponents = Array.isArray(components) ? components : [];


### PR DESCRIPTION
## Summary
- Applies saved profile card background color and opacity on public profile cards
- Keeps existing white-card fallback when no design fields are present
- Preserves text/button opacity by converting hex colors to rgba background values

## Verification
- npm run lint -- --max-warnings 10
- npm run type-check
- npm run build

Closes #35