### PR TITLE
fix: configure Gemini OCR model fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,8 @@ FIREBASE_ADMIN_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\nYOUR_PRIVATE_KEY\n-----
 
 # Google Gemini API
 GEMINI_API_KEY=your_gemini_api_key
+GEMINI_MODEL=gemini-3.1-flash-lite-preview
+GEMINI_FALLBACK_MODEL=gemini-2.5-flash
 
 # Stripe
 STRIPE_PUBLISHABLE_KEY=pk_test_xxx

--- a/src/services/business-card/ocrService.test.ts
+++ b/src/services/business-card/ocrService.test.ts
@@ -1,0 +1,138 @@
+const successfulGeminiResponse = {
+  response: {
+    text: () =>
+      JSON.stringify({
+        lastName: "山田",
+        firstName: "太郎",
+        phoneticLastName: "やまだ",
+        phoneticFirstName: "たろう",
+        company: "",
+        department: "",
+        title: "",
+        addresses: [],
+        email: "",
+        website: "",
+        phoneNumbers: [],
+      }),
+  },
+};
+
+let generateContentMock: jest.Mock;
+let getGenerativeModelMock: jest.Mock;
+
+async function loadOcrService() {
+  jest.resetModules();
+
+  generateContentMock = jest.fn().mockResolvedValue(successfulGeminiResponse);
+  getGenerativeModelMock = jest.fn(() => ({
+    generateContent: generateContentMock,
+  }));
+
+  jest.doMock("@google/generative-ai", () => ({
+    GoogleGenerativeAI: jest.fn(() => ({
+      getGenerativeModel: getGenerativeModelMock,
+    })),
+  }));
+
+  jest.doMock("@/lib/logger", () => ({
+    ocrLogger: {
+      debug: jest.fn(),
+      error: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+    },
+  }));
+
+  return import("./ocrService");
+}
+
+describe("processBusinessCardImage Gemini model selection", () => {
+  beforeEach(() => {
+    process.env.GEMINI_API_KEY = "test-api-key";
+    delete process.env.GEMINI_MODEL;
+    delete process.env.GEMINI_FALLBACK_MODEL;
+  });
+
+  afterEach(() => {
+    delete process.env.GEMINI_API_KEY;
+    delete process.env.GEMINI_MODEL;
+    delete process.env.GEMINI_FALLBACK_MODEL;
+    jest.dontMock("@google/generative-ai");
+    jest.dontMock("@/lib/logger");
+  });
+
+  it("uses the default Gemini model when GEMINI_MODEL is not configured", async () => {
+    const { processBusinessCardImage } = await loadOcrService();
+
+    const result = await processBusinessCardImage("base64-image", "image/png");
+
+    expect(result.success).toBe(true);
+    expect(getGenerativeModelMock).toHaveBeenCalledWith({
+      model: "gemini-3.1-flash-lite-preview",
+    });
+  });
+
+  it("trims configured model names before calling Gemini", async () => {
+    process.env.GEMINI_MODEL = " custom-primary ";
+    const { processBusinessCardImage } = await loadOcrService();
+
+    await processBusinessCardImage("base64-image", "image/png");
+
+    expect(getGenerativeModelMock).toHaveBeenCalledWith({
+      model: "custom-primary",
+    });
+  });
+
+  it("falls back when the primary model is unavailable", async () => {
+    process.env.GEMINI_MODEL = "primary-model";
+    process.env.GEMINI_FALLBACK_MODEL = "fallback-model";
+    const { processBusinessCardImage } = await loadOcrService();
+    generateContentMock
+      .mockRejectedValueOnce(new Error("models/primary-model is not found"))
+      .mockResolvedValueOnce(successfulGeminiResponse);
+
+    const result = await processBusinessCardImage("base64-image", "image/png");
+
+    expect(result.success).toBe(true);
+    expect(getGenerativeModelMock).toHaveBeenNthCalledWith(1, {
+      model: "primary-model",
+    });
+    expect(getGenerativeModelMock).toHaveBeenNthCalledWith(2, {
+      model: "fallback-model",
+    });
+  });
+
+  it("does not fall back for quota errors", async () => {
+    process.env.GEMINI_MODEL = "primary-model";
+    process.env.GEMINI_FALLBACK_MODEL = "fallback-model";
+    const { processBusinessCardImage } = await loadOcrService();
+    generateContentMock.mockRejectedValueOnce(
+      new Error("RESOURCE_EXHAUSTED quota exceeded"),
+    );
+
+    const result = await processBusinessCardImage("base64-image", "image/png");
+
+    expect(result.success).toBe(false);
+    expect(getGenerativeModelMock).toHaveBeenCalledTimes(1);
+    expect(getGenerativeModelMock).toHaveBeenCalledWith({
+      model: "primary-model",
+    });
+  });
+
+  it("does not fall back when the fallback matches the primary model", async () => {
+    process.env.GEMINI_MODEL = "same-model";
+    process.env.GEMINI_FALLBACK_MODEL = "same-model";
+    const { processBusinessCardImage } = await loadOcrService();
+    generateContentMock.mockRejectedValueOnce(
+      new Error("models/same-model is not found"),
+    );
+
+    const result = await processBusinessCardImage("base64-image", "image/png");
+
+    expect(result.success).toBe(false);
+    expect(getGenerativeModelMock).toHaveBeenCalledTimes(1);
+    expect(getGenerativeModelMock).toHaveBeenCalledWith({
+      model: "same-model",
+    });
+  });
+});

--- a/src/services/business-card/ocrService.test.ts
+++ b/src/services/business-card/ocrService.test.ts
@@ -88,7 +88,11 @@ describe("processBusinessCardImage Gemini model selection", () => {
     process.env.GEMINI_FALLBACK_MODEL = "fallback-model";
     const { processBusinessCardImage } = await loadOcrService();
     generateContentMock
-      .mockRejectedValueOnce(new Error("models/primary-model is not found"))
+      .mockRejectedValueOnce(
+        new Error(
+          "[GoogleGenerativeAI Error]: [404 Not Found] models/primary-model is not found for API version v1beta",
+        ),
+      )
       .mockResolvedValueOnce(successfulGeminiResponse);
 
     const result = await processBusinessCardImage("base64-image", "image/png");
@@ -102,13 +106,39 @@ describe("processBusinessCardImage Gemini model selection", () => {
     });
   });
 
-  it("does not fall back for quota errors", async () => {
+  it("falls back when the primary model does not support content generation", async () => {
     process.env.GEMINI_MODEL = "primary-model";
     process.env.GEMINI_FALLBACK_MODEL = "fallback-model";
     const { processBusinessCardImage } = await loadOcrService();
-    generateContentMock.mockRejectedValueOnce(
-      new Error("RESOURCE_EXHAUSTED quota exceeded"),
-    );
+    generateContentMock
+      .mockRejectedValueOnce(
+        new Error("models/primary-model is not supported for generateContent"),
+      )
+      .mockResolvedValueOnce(successfulGeminiResponse);
+
+    const result = await processBusinessCardImage("base64-image", "image/png");
+
+    expect(result.success).toBe(true);
+    expect(getGenerativeModelMock).toHaveBeenNthCalledWith(1, {
+      model: "primary-model",
+    });
+    expect(getGenerativeModelMock).toHaveBeenNthCalledWith(2, {
+      model: "fallback-model",
+    });
+  });
+
+  it.each([
+    "[GoogleGenerativeAI Error]: [429 Too Many Requests] You exceeded your current quota for model gemini-3.1-flash-lite-preview",
+    "Candidate was blocked due to SAFETY. The model returned no content.",
+    "[503 Service Unavailable] The model is overloaded. Please try again later.",
+    "[401 Unauthorized] API key not valid. Please pass a valid API key.",
+    "DEADLINE_EXCEEDED",
+    "Invalid or unsupported image data",
+  ])("does not fall back for non-model-availability errors: %s", async (message) => {
+    process.env.GEMINI_MODEL = "primary-model";
+    process.env.GEMINI_FALLBACK_MODEL = "fallback-model";
+    const { processBusinessCardImage } = await loadOcrService();
+    generateContentMock.mockRejectedValueOnce(new Error(message));
 
     const result = await processBusinessCardImage("base64-image", "image/png");
 
@@ -124,7 +154,9 @@ describe("processBusinessCardImage Gemini model selection", () => {
     process.env.GEMINI_FALLBACK_MODEL = "same-model";
     const { processBusinessCardImage } = await loadOcrService();
     generateContentMock.mockRejectedValueOnce(
-      new Error("models/same-model is not found"),
+      new Error(
+        "[GoogleGenerativeAI Error]: [404 Not Found] models/same-model is not found for API version v1beta",
+      ),
     );
 
     const result = await processBusinessCardImage("base64-image", "image/png");

--- a/src/services/business-card/ocrService.ts
+++ b/src/services/business-card/ocrService.ts
@@ -7,6 +7,7 @@ import { ERROR_MESSAGES } from "@/lib/constants/error-messages";
 import { ocrLogger } from "@/lib/logger";
 import { ContactInfo } from "@/types/business-card";
 import { GoogleGenerativeAI } from "@google/generative-ai";
+import type { GenerateContentResult, Part } from "@google/generative-ai";
 
 // Initialize Gemini AI with API key from environment
 // Use empty string as fallback to avoid build-time errors
@@ -99,19 +100,29 @@ export interface OcrResult {
 }
 
 function getPrimaryGeminiModel() {
-  return process.env.GEMINI_MODEL || DEFAULT_GEMINI_MODEL;
+  return process.env.GEMINI_MODEL?.trim() || DEFAULT_GEMINI_MODEL;
 }
 
-function getFallbackGeminiModel() {
+function getFallbackGeminiModel(primaryModel: string) {
   const fallbackModel =
-    process.env.GEMINI_FALLBACK_MODEL || DEFAULT_GEMINI_FALLBACK_MODEL;
-  return fallbackModel === getPrimaryGeminiModel() ? null : fallbackModel;
+    process.env.GEMINI_FALLBACK_MODEL?.trim() || DEFAULT_GEMINI_FALLBACK_MODEL;
+  return fallbackModel === primaryModel ? null : fallbackModel;
 }
 
-async function generateOcrContent(
-  modelName: string,
-  imagePart: { inlineData: { data: string; mimeType: string } },
-) {
+function isModelAvailabilityError(error: unknown) {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  const message = error.message.toLowerCase();
+  return (
+    message.includes("model") ||
+    message.includes("not found") ||
+    message.includes("not supported")
+  );
+}
+
+async function generateOcrContent(modelName: string, imagePart: Part) {
   const model = genAI.getGenerativeModel({ model: modelName });
 
   return model.generateContent({
@@ -231,14 +242,14 @@ export async function processBusinessCardImage(
     };
 
     const primaryModelName = getPrimaryGeminiModel();
-    const fallbackModelName = getFallbackGeminiModel();
-    let result;
+    const fallbackModelName = getFallbackGeminiModel(primaryModelName);
+    let result: GenerateContentResult;
 
     try {
       ocrLogger.info("Calling Gemini API with model:", primaryModelName);
       result = await generateOcrContent(primaryModelName, imagePart);
     } catch (primaryError) {
-      if (!fallbackModelName) {
+      if (!fallbackModelName || !isModelAvailabilityError(primaryError)) {
         throw primaryError;
       }
 
@@ -246,7 +257,10 @@ export async function processBusinessCardImage(
         "Primary Gemini model failed; retrying with fallback model:",
         fallbackModelName,
       );
-      ocrLogger.warn("Primary Gemini error:", primaryError);
+      ocrLogger.warn(
+        "Primary Gemini error:",
+        primaryError instanceof Error ? primaryError.message : String(primaryError),
+      );
       result = await generateOcrContent(fallbackModelName, imagePart);
     }
 

--- a/src/services/business-card/ocrService.ts
+++ b/src/services/business-card/ocrService.ts
@@ -114,12 +114,13 @@ function isModelAvailabilityError(error: unknown) {
     return false;
   }
 
-  const message = error.message.toLowerCase();
-  return (
-    message.includes("model") ||
-    message.includes("not found") ||
-    message.includes("not supported")
-  );
+  const message = error.message;
+  const referencesModel = /\bmodels\/[\w.-]+/i.test(message);
+  const modelNotFound =
+    /\[404[^\]]*\]/i.test(message) && /\bnot found\b/i.test(message);
+  const modelMethodUnsupported = /\bis not supported for\b/i.test(message);
+
+  return referencesModel && (modelNotFound || modelMethodUnsupported);
 }
 
 async function generateOcrContent(modelName: string, imagePart: Part) {

--- a/src/services/business-card/ocrService.ts
+++ b/src/services/business-card/ocrService.ts
@@ -13,6 +13,9 @@ import { GoogleGenerativeAI } from "@google/generative-ai";
 // Actual validation happens at runtime in processBusinessCardImage
 const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY || "");
 
+const DEFAULT_GEMINI_MODEL = "gemini-3.1-flash-lite-preview";
+const DEFAULT_GEMINI_FALLBACK_MODEL = "gemini-2.5-flash";
+
 // Empty contact info template
 const emptyContactInfo: ContactInfo = {
   lastName: "",
@@ -46,6 +49,12 @@ const OCR_PROMPT = `
 - ロゴマークと文字の区別
 - 姓と名の区切り位置（スペースがなくても文脈で判断）
 
+【抽出原則】
+- 画像上に明確に表示されている情報のみ抽出してください
+- メールアドレスのローカル部やドメイン名から、氏名・会社名・部署名・役職を推測してはいけません
+- 推測できそうでも、画像上に文字として存在しない項目は空文字列にしてください
+- 会社ロゴやメールドメインは、会社名の根拠として使わないでください
+
 【電話番号の自動分類ルール】
 - 携帯/Mobile: 070, 080, 090, 050で始まる
 - FAX: FAX, Fax, ファックスの記載がある、または03等で始まり2番目の番号
@@ -54,7 +63,7 @@ const OCR_PROMPT = `
 【メールアドレスの検証】
 - @マークの前後を慎重に確認
 - よくあるドメイン: gmail.com, yahoo.co.jp, outlook.jp等
-- 企業ドメインは会社名と照合
+- 企業ドメインから会社名を補完しない
 
 【出力形式】
 必ず以下のキーを持つJSONオブジェクトを返してください：
@@ -87,6 +96,39 @@ export interface OcrResult {
   contactInfo?: ContactInfo;
   processingTime: number;
   error?: string;
+}
+
+function getPrimaryGeminiModel() {
+  return process.env.GEMINI_MODEL || DEFAULT_GEMINI_MODEL;
+}
+
+function getFallbackGeminiModel() {
+  const fallbackModel =
+    process.env.GEMINI_FALLBACK_MODEL || DEFAULT_GEMINI_FALLBACK_MODEL;
+  return fallbackModel === getPrimaryGeminiModel() ? null : fallbackModel;
+}
+
+async function generateOcrContent(
+  modelName: string,
+  imagePart: { inlineData: { data: string; mimeType: string } },
+) {
+  const model = genAI.getGenerativeModel({ model: modelName });
+
+  return model.generateContent({
+    contents: [
+      {
+        role: "user",
+        parts: [imagePart, { text: OCR_PROMPT }],
+      },
+    ],
+    generationConfig: {
+      responseMimeType: "application/json",
+      temperature: 0.1,
+      topP: 0.8,
+      topK: 40,
+      maxOutputTokens: 2048,
+    },
+  });
 }
 
 /**
@@ -154,7 +196,7 @@ export async function processBusinessCardImage(
   // Log HEIC format detection for monitoring
   if (mimeType === "image/heic" || mimeType === "image/heif") {
     ocrLogger.info("📱 HEIC format detected from mobile device");
-    ocrLogger.debug("Gemini Flash Latest should support HEIC format");
+    ocrLogger.debug("Configured Gemini model should support HEIC format");
     ocrLogger.debug("HEIC image size:", Math.round(image.length / 1024), "KB");
   }
 
@@ -172,9 +214,6 @@ export async function processBusinessCardImage(
     }
     ocrLogger.debug("✅ Starting OCR processing");
 
-    // Get the generative model (Gemini Flash Latest for maximum compatibility)
-    const model = genAI.getGenerativeModel({ model: "gemini-flash-latest" });
-
     // Remove data URL prefix if present
     const base64Image = image.replace(/^data:image\/\w+;base64,/, "");
     ocrLogger.debug(
@@ -182,9 +221,6 @@ export async function processBusinessCardImage(
       base64Image.length,
       "characters",
     );
-
-    // Generate content with Gemini (no timeout - let it complete naturally)
-    ocrLogger.debug("Calling Gemini API...");
 
     // Use more robust API call format with explicit content structure
     const imagePart = {
@@ -194,21 +230,25 @@ export async function processBusinessCardImage(
       },
     };
 
-    const result = await model.generateContent({
-      contents: [
-        {
-          role: "user",
-          parts: [imagePart, { text: OCR_PROMPT }],
-        },
-      ],
-      generationConfig: {
-        responseMimeType: "application/json",
-        temperature: 0.1,
-        topP: 0.8,
-        topK: 40,
-        maxOutputTokens: 2048,
-      },
-    });
+    const primaryModelName = getPrimaryGeminiModel();
+    const fallbackModelName = getFallbackGeminiModel();
+    let result;
+
+    try {
+      ocrLogger.info("Calling Gemini API with model:", primaryModelName);
+      result = await generateOcrContent(primaryModelName, imagePart);
+    } catch (primaryError) {
+      if (!fallbackModelName) {
+        throw primaryError;
+      }
+
+      ocrLogger.warn(
+        "Primary Gemini model failed; retrying with fallback model:",
+        fallbackModelName,
+      );
+      ocrLogger.warn("Primary Gemini error:", primaryError);
+      result = await generateOcrContent(fallbackModelName, imagePart);
+    }
 
     if (!result || !result.response) {
       ocrLogger.error("❌ No response from Gemini API");
@@ -330,7 +370,10 @@ export async function processBusinessCardImage(
         }
       }
 
-      ocrLogger.debug("📝 Final JSON text:", jsonText.substring(0, 200) + "...");
+      ocrLogger.debug(
+        "📝 Final JSON text:",
+        jsonText.substring(0, 200) + "...",
+      );
 
       // Parse JSON with detailed error handling
       let parsedJson;


### PR DESCRIPTION
## Summary
- Defaults OCR to `gemini-3.1-flash-lite-preview` with `gemini-2.5-flash` fallback
- Documents `GEMINI_MODEL` and `GEMINI_FALLBACK_MODEL` in `.env.example`
- Tightens OCR prompt to avoid inferring names/company from email-only images

## Verification
- npm run lint -- --max-warnings 10
- npm run type-check
- npm run build
- Minimal Gemini API request accepted `gemini-3.1-flash-lite-preview`

Closes #36
Closes #39