### PR TITLE
fix: スキャン数2重カウントとクォータ自動更新の修正

### DIFF
--- a/src/app/api/business-card/scan/route.ts
+++ b/src/app/api/business-card/scan/route.ts
@@ -5,10 +5,7 @@ import {
 import { verifyIdToken } from "@/lib/firebase-admin";
 import { strictRateLimit } from "@/lib/rateLimit";
 import { processBusinessCardImage } from "@/services/business-card/ocrService";
-import {
-  canScan,
-  recordScan,
-} from "@/services/business-card/scanQuotaService.server";
+import { canScan } from "@/services/business-card/scanQuotaService.server";
 import {
   ApiErrorResponse,
   BusinessCardScanRequest,
@@ -140,22 +137,6 @@ export async function POST(request: NextRequest) {
 
     console.log("✅ OCR processing succeeded");
     console.log("Processing time:", ocrResult.processingTime, "ms");
-
-    // Record the scan to Firestore and update quota
-    console.log("Recording scan to database...");
-    const recordResult = await recordScan(userId, ocrResult.contactInfo);
-    if (!recordResult.success) {
-      console.error("❌ Failed to record scan:", recordResult.error);
-      // DB保存失敗時は上限カウントされないため、エラーを返す
-      // これにより無限スキャンの抜け穴を防ぐ
-      const errorResponse: ApiErrorResponse = {
-        success: false,
-        error: API_ERROR_CODES.SCAN_SAVE_FAILED,
-        details: recordResult.error,
-      };
-      return NextResponse.json(errorResponse, { status: 500 });
-    }
-    console.log("✅ Scan recorded successfully, docId:", recordResult.docId);
 
     const successResponse: BusinessCardScanResponse = {
       success: true,

--- a/src/app/dashboard/business-cards/scan/page.tsx
+++ b/src/app/dashboard/business-cards/scan/page.tsx
@@ -35,16 +35,16 @@ export default function BusinessCardScanPage() {
   const [scanQuota, setScanQuota] = useState<ScanQuota | null>(null);
   const [userProfile, setUserProfile] = useState<any>(null);
 
-  // スキャン上限情報を取得
-  useEffect(() => {
-    const fetchQuota = async () => {
-      if (user?.uid) {
-        const quota = await getScanQuota(user.uid);
-        setScanQuota(quota);
-      }
-    };
-    fetchQuota();
+  const refreshQuota = useCallback(async () => {
+    if (user?.uid) {
+      const quota = await getScanQuota(user.uid);
+      setScanQuota(quota);
+    }
   }, [user]);
+
+  useEffect(() => {
+    refreshQuota();
+  }, [refreshQuota]);
 
   // ユーザープロファイルを取得
   useEffect(() => {
@@ -224,7 +224,7 @@ export default function BusinessCardScanPage() {
         description: SUCCESS_MESSAGES.VCARD_DOWNLOAD_SUCCESS,
       });
 
-      // Reset to initial state
+      await refreshQuota();
       handleReset();
     } catch (e) {
       console.error(e);


### PR DESCRIPTION
## Summary

- **Bug #46**: 名刺スキャン後、スキャナー画面に戻ってもスキャン残数が自動更新されない問題を修正
- **Bug #47**: 今月のスキャン数が実際のスキャン枚数より多くなる（2重カウント）問題を修正

## Changes

### Bug #46 修正: クォータ自動更新
- `refreshQuota` コールバックを追加し、保存後にクォータを再取得
- `useEffect` を `refreshQuota` に依存させることで正確な依存配列に修正

### Bug #47 修正: 2重書き込みの排除
- **原因**: API route (`route.ts`) のOCR成功時とクライアント保存時の2箇所で `recordScan` を呼び出し、Firestoreに2つのドキュメントを作成していた
- **修正**: API route側の `recordScan` を削除。OCR結果はクライアントに返すのみとし、ユーザーが保存を確定した時のみクライアント側で `recordScan` を実行

Closes #46, Closes #47