### PR TITLE
Release profile privacy and scan UX fixes

### DIFF
--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -7,20 +7,20 @@ test.describe("認証フロー", () => {
 
   test("ランディングページから認証ページへ遷移", async ({ page }) => {
     // ランディングページの確認
-    await expect(page).toHaveTitle(/NFC Profile Card/);
+    await expect(page).toHaveTitle(/TapForge/);
 
     // サインインボタンをクリック
-    const signInButton =
-      page.getByRole("link", { name: /sign in/i }) ||
-      page.getByRole("button", { name: /sign in/i }) ||
-      page.locator("text=サインイン").first();
+    const signInButton = page
+      .getByRole("link", { name: /ログイン|sign in/i })
+      .first();
     await signInButton.click();
 
     // サインインページへの遷移を確認
-    await expect(page).toHaveURL("/signin");
-    await expect(page.locator("h1, h2").first()).toContainText(
-      /サインイン|Sign In/i,
-    );
+    await expect(page).toHaveURL(/\/signin/);
+    await expect(page.locator('input[type="email"]').first()).toBeVisible();
+    await expect(
+      page.getByRole("tab", { name: /ログイン|sign in/i }),
+    ).toBeVisible();
   });
 
   test("メールアドレスでの新規登録フロー", async ({ page }) => {

--- a/src/app/api/admin/users/[uid]/rotate-username/route.ts
+++ b/src/app/api/admin/users/[uid]/rotate-username/route.ts
@@ -1,0 +1,83 @@
+import { verifyAdminRequest } from "@/lib/admin";
+import { adminDb } from "@/lib/firebase-admin";
+import { generateDefaultUsername } from "@/lib/username";
+import { FieldValue } from "firebase-admin/firestore";
+import { NextRequest, NextResponse } from "next/server";
+
+interface RouteContext {
+  params: {
+    uid: string;
+  };
+}
+
+async function generateUniqueUsername() {
+  for (let attempt = 0; attempt < 5; attempt += 1) {
+    const username = generateDefaultUsername();
+    const snapshot = await adminDb
+      .collection("users")
+      .where("username", "==", username)
+      .limit(1)
+      .get();
+
+    if (snapshot.empty) {
+      return username;
+    }
+  }
+
+  throw new Error("Failed to generate unique username");
+}
+
+export async function POST(request: NextRequest, { params }: RouteContext) {
+  try {
+    const admin = await verifyAdminRequest(request);
+    if (!admin.ok) {
+      return NextResponse.json(
+        { error: admin.error },
+        { status: admin.status },
+      );
+    }
+
+    const userRef = adminDb.collection("users").doc(params.uid);
+    const username = await generateUniqueUsername();
+    const result = await adminDb.runTransaction(async (transaction) => {
+      const userDoc = await transaction.get(userRef);
+      if (!userDoc.exists) {
+        return null;
+      }
+
+      const data = userDoc.data() || {};
+      const previousUsername = data.username || "";
+
+      const updateData: Record<string, unknown> = {
+        username,
+        usernameRotatedAt: FieldValue.serverTimestamp(),
+        usernameRotatedBy: admin.decodedToken.uid,
+        updatedAt: FieldValue.serverTimestamp(),
+      };
+
+      if (previousUsername) {
+        updateData.previousUsernames = FieldValue.arrayUnion(previousUsername);
+      }
+
+      transaction.update(userRef, updateData);
+
+      return {
+        uid: params.uid,
+        previousUsername,
+        username,
+      };
+    });
+
+    if (!result) {
+      return NextResponse.json({ error: "User not found" }, { status: 404 });
+    }
+
+    return NextResponse.json(result);
+  } catch (error) {
+    console.error("Admin username rotation failed:", error);
+    return NextResponse.json(
+      { error: "Failed to rotate username" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/admin/users/[uid]/route.ts
+++ b/src/app/api/admin/users/[uid]/route.ts
@@ -1,0 +1,50 @@
+import { verifyAdminRequest } from "@/lib/admin";
+import { adminDb } from "@/lib/firebase-admin";
+import { NextRequest, NextResponse } from "next/server";
+
+interface RouteContext {
+  params: {
+    uid: string;
+  };
+}
+
+function isLikelyEmailDerivedUsername(username?: string, email?: string) {
+  if (!username || !email || !email.includes("@")) return false;
+  return username === email.split("@")[0];
+}
+
+export async function GET(request: NextRequest, { params }: RouteContext) {
+  try {
+    const admin = await verifyAdminRequest(request);
+    if (!admin.ok) {
+      return NextResponse.json(
+        { error: admin.error },
+        { status: admin.status },
+      );
+    }
+
+    const userDoc = await adminDb.collection("users").doc(params.uid).get();
+    if (!userDoc.exists) {
+      return NextResponse.json({ error: "User not found" }, { status: 404 });
+    }
+
+    const data = userDoc.data() || {};
+
+    return NextResponse.json({
+      uid: params.uid,
+      email: data.email || null,
+      name: data.name || data.displayName || "",
+      username: data.username || "",
+      isLikelyEmailDerivedUsername: isLikelyEmailDerivedUsername(
+        data.username,
+        data.email,
+      ),
+    });
+  } catch (error) {
+    console.error("Admin user lookup failed:", error);
+    return NextResponse.json(
+      { error: "Failed to lookup user" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/analytics/track/route.ts
+++ b/src/app/api/analytics/track/route.ts
@@ -32,7 +32,16 @@ export async function POST(request: NextRequest) {
       .limit(1)
       .get();
 
-    if (snapshot.empty) {
+    let userRef = snapshot.docs[0]?.ref;
+
+    if (!userRef && username.startsWith("u_")) {
+      const uidDoc = await usersRef.doc(username.slice(2)).get();
+      if (uidDoc.exists) {
+        userRef = uidDoc.ref;
+      }
+    }
+
+    if (!userRef) {
       return NextResponse.json({ error: "User not found" }, { status: 404 });
     }
 
@@ -41,7 +50,6 @@ export async function POST(request: NextRequest) {
     const safeUserAgent =
       request.headers.get("user-agent")?.slice(0, 500) || "unknown";
 
-    const userRef = snapshot.docs[0].ref;
     const now = new Date();
     const today = now.toISOString().split("T")[0];
 

--- a/src/app/api/vcard/route.ts
+++ b/src/app/api/vcard/route.ts
@@ -1,7 +1,14 @@
 import { NextRequest, NextResponse } from "next/server";
 import vCardsJS from "vcards-js";
 import { db } from "@/lib/firebase";
-import { collection, getDocs, query, where } from "firebase/firestore";
+import {
+  collection,
+  doc,
+  getDoc,
+  getDocs,
+  query,
+  where,
+} from "firebase/firestore";
 import { standardRateLimit } from "@/lib/rateLimit";
 
 export interface VCardData {
@@ -178,12 +185,20 @@ export async function GET(request: NextRequest) {
     const q = query(usersRef, where("username", "==", username));
     const snapshot = await getDocs(q);
 
-    if (snapshot.empty) {
+    let profile = snapshot.docs[0]?.data();
+
+    if (!profile && username.startsWith("u_")) {
+      const userDoc = await getDoc(doc(db, "users", username.slice(2)));
+      if (userDoc.exists()) {
+        profile = userDoc.data();
+      }
+    }
+
+    if (!profile) {
       console.error("Profile not found for username:", username);
       return NextResponse.json({ error: "Profile not found" }, { status: 404 });
     }
 
-    const profile = snapshot.docs[0].data();
     console.log("Profile data:", profile);
 
     // シンプルなVCardフォーマットで直接生成

--- a/src/app/dashboard/admin/page.tsx
+++ b/src/app/dashboard/admin/page.tsx
@@ -1,0 +1,236 @@
+"use client";
+
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { useAuth } from "@/contexts/AuthContext";
+import { AlertTriangle, Loader2, RotateCcw, Search } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+
+interface AdminUser {
+  uid: string;
+  email: string | null;
+  name: string;
+  username: string;
+  isLikelyEmailDerivedUsername: boolean;
+}
+
+export default function AdminPage() {
+  const { user, loading } = useAuth();
+  const router = useRouter();
+  const [uid, setUid] = useState("");
+  const [targetUser, setTargetUser] = useState<AdminUser | null>(null);
+  const [error, setError] = useState("");
+  const [message, setMessage] = useState("");
+  const [isLookingUp, setIsLookingUp] = useState(false);
+  const [isRotating, setIsRotating] = useState(false);
+
+  useEffect(() => {
+    if (!loading && !user) {
+      router.push("/signin");
+    }
+  }, [loading, router, user]);
+
+  const getAuthorizationHeader = async () => {
+    if (!user) {
+      throw new Error("ログインが必要です");
+    }
+
+    return `Bearer ${await user.getIdToken()}`;
+  };
+
+  const lookupUser = async () => {
+    const normalizedUid = uid.trim();
+    if (!normalizedUid) {
+      setError("対象ユーザーのUIDを入力してください。");
+      return;
+    }
+
+    setError("");
+    setMessage("");
+    setTargetUser(null);
+    setIsLookingUp(true);
+
+    try {
+      const response = await fetch(`/api/admin/users/${normalizedUid}`, {
+        headers: {
+          Authorization: await getAuthorizationHeader(),
+        },
+      });
+      const data = await response.json();
+
+      if (!response.ok) {
+        throw new Error(data.error || "ユーザー取得に失敗しました。");
+      }
+
+      setTargetUser(data);
+    } catch (err: any) {
+      setError(err.message || "ユーザー取得に失敗しました。");
+    } finally {
+      setIsLookingUp(false);
+    }
+  };
+
+  const rotateUsername = async () => {
+    if (!targetUser) return;
+
+    const confirmed = window.confirm(
+      `公開URL IDを変更します。古いURL /p/${targetUser.username} は使えなくなります。続行しますか？`,
+    );
+    if (!confirmed) return;
+
+    setError("");
+    setMessage("");
+    setIsRotating(true);
+
+    try {
+      const response = await fetch(
+        `/api/admin/users/${targetUser.uid}/rotate-username`,
+        {
+          method: "POST",
+          headers: {
+            Authorization: await getAuthorizationHeader(),
+          },
+        },
+      );
+      const data = await response.json();
+
+      if (!response.ok) {
+        throw new Error(data.error || "公開URL IDの変更に失敗しました。");
+      }
+
+      setTargetUser((current) =>
+        current ? { ...current, username: data.username } : current,
+      );
+      setMessage(
+        `公開URL IDを ${data.previousUsername || "(未設定)"} から ${data.username} に変更しました。`,
+      );
+    } catch (err: any) {
+      setError(err.message || "公開URL IDの変更に失敗しました。");
+    } finally {
+      setIsRotating(false);
+    }
+  };
+
+  if (loading || !user) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <Loader2 className="h-8 w-8 animate-spin" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto max-w-3xl px-4 py-6">
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold text-gray-900">管理</h1>
+        <p className="mt-1 text-sm text-gray-600">
+          メール由来の公開URL IDをランダムなIDに変更します。
+        </p>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>公開URL IDのローテーション</CardTitle>
+          <CardDescription>
+            対象ユーザーのFirebase Auth UIDを指定してください。
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="uid">ユーザーUID</Label>
+            <div className="flex flex-col gap-2 sm:flex-row">
+              <Input
+                id="uid"
+                value={uid}
+                onChange={(event) => setUid(event.target.value)}
+                placeholder="Firebase Auth UID"
+              />
+              <Button
+                onClick={lookupUser}
+                disabled={isLookingUp}
+                className="w-full sm:w-auto"
+              >
+                {isLookingUp ? (
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                ) : (
+                  <Search className="mr-2 h-4 w-4" />
+                )}
+                検索
+              </Button>
+            </div>
+          </div>
+
+          {error && (
+            <Alert variant="destructive">
+              <AlertTriangle className="h-4 w-4" />
+              <AlertTitle>エラー</AlertTitle>
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
+          )}
+
+          {message && (
+            <Alert>
+              <AlertTitle>完了</AlertTitle>
+              <AlertDescription>{message}</AlertDescription>
+            </Alert>
+          )}
+
+          {targetUser && (
+            <div className="rounded-md border p-4">
+              <div className="mb-3 flex items-center justify-between gap-3">
+                <div>
+                  <p className="text-sm font-medium text-gray-900">
+                    {targetUser.name || "(名前未設定)"}
+                  </p>
+                  <p className="text-xs text-gray-600">{targetUser.email}</p>
+                </div>
+                {targetUser.isLikelyEmailDerivedUsername && (
+                  <Badge variant="destructive">メール由来の可能性</Badge>
+                )}
+              </div>
+
+              <dl className="mb-4 grid gap-2 text-sm">
+                <div className="grid grid-cols-[120px_1fr] gap-2">
+                  <dt className="text-gray-500">現在のID</dt>
+                  <dd className="font-mono">
+                    {targetUser.username || "(未設定)"}
+                  </dd>
+                </div>
+                <div className="grid grid-cols-[120px_1fr] gap-2">
+                  <dt className="text-gray-500">公開URL</dt>
+                  <dd className="font-mono">
+                    /p/{targetUser.username || `u_${targetUser.uid}`}
+                  </dd>
+                </div>
+              </dl>
+
+              <Button
+                onClick={rotateUsername}
+                disabled={isRotating}
+                variant="destructive"
+              >
+                {isRotating ? (
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                ) : (
+                  <RotateCcw className="mr-2 h-4 w-4" />
+                )}
+                ランダムIDに変更
+              </Button>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/dashboard/business-cards/scan/page.tsx
+++ b/src/app/dashboard/business-cards/scan/page.tsx
@@ -17,6 +17,10 @@ import {
   recordScan,
   type ScanQuota,
 } from "@/services/business-card/scanQuotaService";
+import {
+  enhanceBusinessCardImage,
+  type EnhancedImageResult,
+} from "@/services/business-card/imageEnhancement";
 import { downloadVCard } from "@/services/business-card/vcardService";
 import { AppStatus, ContactInfo } from "@/types/business-card";
 import { doc, getDoc } from "firebase/firestore";
@@ -32,6 +36,11 @@ export default function BusinessCardScanPage() {
   const [error, setError] = useState<string | null>(null);
   const [imageBase64, setImageBase64] = useState<string | null>(null);
   const [imageMimeType, setImageMimeType] = useState<string | null>(null);
+  const [enhancedImage, setEnhancedImage] =
+    useState<EnhancedImageResult | null>(null);
+  const [imageQualityWarnings, setImageQualityWarnings] = useState<string[]>(
+    [],
+  );
   const [scanQuota, setScanQuota] = useState<ScanQuota | null>(null);
   const [userProfile, setUserProfile] = useState<any>(null);
 
@@ -65,10 +74,12 @@ export default function BusinessCardScanPage() {
   }, [user]);
 
   const handleImageSelected = useCallback(
-    async (file: File) => {
+    async (file: File, warnings: string[]) => {
       setAppStatus(AppStatus.PROCESSING);
       setError(null);
       setContactInfo(null);
+      setEnhancedImage(null);
+      setImageQualityWarnings(warnings);
 
       // Log HEIC format detection for monitoring
       if (file.type === "image/heic" || file.type === "image/heif") {
@@ -91,6 +102,18 @@ export default function BusinessCardScanPage() {
         setImageMimeType(file.type);
 
         try {
+          let imageForOcr = base64Data;
+          let mimeTypeForOcr = file.type;
+
+          try {
+            const enhanced = await enhanceBusinessCardImage(base64Data);
+            setEnhancedImage(enhanced);
+            imageForOcr = enhanced.dataUrl;
+            mimeTypeForOcr = enhanced.mimeType;
+          } catch (enhanceError) {
+            console.warn("Image enhancement skipped:", enhanceError);
+          }
+
           // Get ID token for authentication
           const idToken = await getIdToken();
           if (!idToken) {
@@ -105,8 +128,8 @@ export default function BusinessCardScanPage() {
               Authorization: `Bearer ${idToken}`,
             },
             body: JSON.stringify({
-              image: base64Data,
-              mimeType: file.type,
+              image: imageForOcr,
+              mimeType: mimeTypeForOcr,
             }),
           });
 
@@ -200,10 +223,18 @@ export default function BusinessCardScanPage() {
     [getIdToken, t],
   );
 
-  const handleSaveContact = async (updatedContactInfo: ContactInfo) => {
+  const handleSaveContact = async (
+    updatedContactInfo: ContactInfo,
+    selectedImageBase64?: string | null,
+    selectedImageMimeType?: string | null,
+  ) => {
     try {
       // Download vCard
-      downloadVCard(updatedContactInfo, imageBase64, imageMimeType);
+      downloadVCard(
+        updatedContactInfo,
+        selectedImageBase64 ?? imageBase64,
+        selectedImageMimeType ?? imageMimeType,
+      );
 
       // Save to Firestore with quota check
       if (user?.uid) {
@@ -243,6 +274,8 @@ export default function BusinessCardScanPage() {
     setError(null);
     setImageBase64(null);
     setImageMimeType(null);
+    setEnhancedImage(null);
+    setImageQualityWarnings([]);
   };
 
   const renderContent = () => {
@@ -258,6 +291,9 @@ export default function BusinessCardScanPage() {
               onCancel={handleReset}
               imageBase64={imageBase64}
               imageMimeType={imageMimeType}
+              enhancedImageBase64={enhancedImage?.base64 || null}
+              enhancedImageMimeType={enhancedImage?.mimeType || null}
+              imageQualityWarnings={imageQualityWarnings}
             />
           );
         }

--- a/src/app/dashboard/edit/page.tsx
+++ b/src/app/dashboard/edit/page.tsx
@@ -14,7 +14,9 @@ import { Textarea } from "@/components/ui/textarea";
 import { toast } from "@/components/ui/use-toast";
 import { useAuth } from "@/contexts/AuthContext";
 import { useLanguage } from "@/contexts/LanguageContext";
+import { BIO_MAX_LENGTH, BIO_WARNING_THRESHOLD } from "@/lib/constants/profile";
 import { db } from "@/lib/firebase";
+import { getUidFallbackUsername } from "@/lib/username";
 import { doc, getDoc, serverTimestamp, setDoc } from "firebase/firestore";
 import { Loader2, Palette, Save } from "lucide-react";
 import { useRouter } from "next/navigation";
@@ -60,7 +62,7 @@ export default function EditProfilePage() {
         const data = userDoc.data();
         setProfile({
           name: data.name || user.displayName || "",
-          username: data.username || user.email?.split("@")[0] || "",
+          username: data.username || getUidFallbackUsername(user.uid),
           bio: data.bio || "",
           company: data.company || "",
           position: data.position || "",
@@ -73,7 +75,7 @@ export default function EditProfilePage() {
         setProfile((prev) => ({
           ...prev,
           name: user.displayName || "",
-          username: user.email?.split("@")[0] || "",
+          username: getUidFallbackUsername(user.uid),
           email: user.email || "",
         }));
       }
@@ -269,8 +271,25 @@ export default function EditProfilePage() {
                 value={profile.bio}
                 onChange={(e) => handleInputChange("bio", e.target.value)}
                 placeholder={t("bioPlaceholder")}
+                maxLength={BIO_MAX_LENGTH}
                 rows={4}
               />
+              <div className="flex items-center justify-between text-xs">
+                <span
+                  className={
+                    profile.bio.length >= BIO_WARNING_THRESHOLD
+                      ? "text-amber-600"
+                      : "text-muted-foreground"
+                  }
+                >
+                  {profile.bio.length >= BIO_WARNING_THRESHOLD
+                    ? t("bioLimitWarning")
+                    : ""}
+                </span>
+                <span className="text-muted-foreground">
+                  {profile.bio.length} / {BIO_MAX_LENGTH}
+                </span>
+              </div>
             </div>
           </CardContent>
         </Card>

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -132,8 +132,7 @@ export default function DashboardPage() {
             <div>
               <h1 className="text-2xl font-bold text-gray-900">{t("title")}</h1>
               <p className="text-sm text-gray-600 mt-1">
-                {t("welcome")},{" "}
-                {user?.displayName || user?.email?.split("@")[0]}
+                {t("welcome")}, {user?.displayName || t("profile")}
               </p>
             </div>
 

--- a/src/app/p/[username]/page.tsx
+++ b/src/app/p/[username]/page.tsx
@@ -6,6 +6,7 @@ import { adminDb } from "@/lib/firebase-admin";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import type { Metadata } from "next";
+import type { DocumentSnapshot } from "firebase-admin/firestore";
 import { cache } from "react";
 
 export const revalidate = 300;
@@ -46,12 +47,22 @@ const fetchUserData = cache(async (username: string) => {
       .limit(1)
       .get();
 
-    if (snapshot.empty) {
+    let userDoc: DocumentSnapshot | undefined = snapshot.docs[0];
+
+    if (!userDoc && username.startsWith("u_")) {
+      const uid = username.slice(2);
+      const uidDoc = await adminDb.collection("users").doc(uid).get();
+      if (uidDoc.exists) {
+        userDoc = uidDoc;
+      }
+    }
+
+    if (!userDoc) {
       return { user: null, profileData: null };
     }
 
-    const userData = snapshot.docs[0].data() as UserProfile;
-    const userId = snapshot.docs[0].id;
+    const userData = userDoc.data() as UserProfile;
+    const userId = userDoc.id;
 
     let profileData = null;
     try {

--- a/src/components/business-card/ContactForm.tsx
+++ b/src/components/business-card/ContactForm.tsx
@@ -3,6 +3,7 @@
 import React, { useState, useCallback, useEffect } from "react";
 import { ContactInfo, PhoneNumber, Address } from "@/types/business-card";
 import { generateVCard } from "@/services/business-card/vcardService";
+import Image from "next/image";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -14,15 +15,28 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { ChevronDown, ChevronUp, Plus, Trash2 } from "lucide-react";
+import {
+  AlertTriangle,
+  ChevronDown,
+  ChevronUp,
+  Plus,
+  Trash2,
+} from "lucide-react";
 import { useLanguage } from "@/contexts/LanguageContext";
 
 interface ContactFormProps {
   initialData: ContactInfo;
-  onSave: (data: ContactInfo) => void;
+  onSave: (
+    data: ContactInfo,
+    selectedImageBase64?: string | null,
+    selectedImageMimeType?: string | null,
+  ) => void;
   onCancel: () => void;
   imageBase64?: string | null;
   imageMimeType?: string | null;
+  enhancedImageBase64?: string | null;
+  enhancedImageMimeType?: string | null;
+  imageQualityWarnings?: string[];
 }
 
 const ContactForm: React.FC<ContactFormProps> = ({
@@ -31,11 +45,26 @@ const ContactForm: React.FC<ContactFormProps> = ({
   onCancel,
   imageBase64,
   imageMimeType,
+  enhancedImageBase64,
+  enhancedImageMimeType,
+  imageQualityWarnings = [],
 }) => {
   const [formData, setFormData] = useState<ContactInfo>(initialData);
   const [vcardPreview, setVcardPreview] = useState("");
   const [isPreviewCollapsed, setIsPreviewCollapsed] = useState(true);
+  const [imageVariant, setImageVariant] = useState<"enhanced" | "original">(
+    enhancedImageBase64 ? "enhanced" : "original",
+  );
   const { t } = useLanguage();
+
+  const selectedImageBase64 =
+    imageVariant === "enhanced" && enhancedImageBase64
+      ? enhancedImageBase64
+      : imageBase64;
+  const selectedImageMimeType =
+    imageVariant === "enhanced" && enhancedImageMimeType
+      ? enhancedImageMimeType
+      : imageMimeType;
 
   useEffect(() => {
     setFormData(initialData);
@@ -45,12 +74,18 @@ const ContactForm: React.FC<ContactFormProps> = ({
     if (formData) {
       const vcardString = generateVCard(
         formData,
-        imageBase64 || null,
-        imageMimeType || null,
+        selectedImageBase64 || null,
+        selectedImageMimeType || null,
       );
       setVcardPreview(vcardString);
     }
-  }, [formData, imageBase64, imageMimeType]);
+  }, [formData, selectedImageBase64, selectedImageMimeType]);
+
+  useEffect(() => {
+    if (!enhancedImageBase64) {
+      setImageVariant("original");
+    }
+  }, [enhancedImageBase64]);
 
   const handleChange = useCallback(
     (field: keyof Omit<ContactInfo, "phoneNumbers" | "addresses">) =>
@@ -117,6 +152,69 @@ const ContactForm: React.FC<ContactFormProps> = ({
         </h2>
 
         <div className="space-y-6">
+          {imageQualityWarnings.length > 0 && (
+            <div className="rounded-lg border border-amber-200 bg-amber-50 p-3 text-amber-800">
+              <div className="flex items-start gap-2">
+                <AlertTriangle className="mt-0.5 h-4 w-4 flex-shrink-0" />
+                <div className="space-y-1 text-sm">
+                  {imageQualityWarnings.map((warning) => (
+                    <p key={warning}>{warning}</p>
+                  ))}
+                </div>
+              </div>
+            </div>
+          )}
+
+          {imageBase64 && enhancedImageBase64 && (
+            <div className="space-y-3">
+              <Label>{t("vcardImageChoice")}</Label>
+              <div className="grid grid-cols-2 gap-3">
+                <button
+                  type="button"
+                  onClick={() => setImageVariant("enhanced")}
+                  className={`rounded-md border p-2 text-left transition ${
+                    imageVariant === "enhanced"
+                      ? "border-blue-500 bg-blue-50"
+                      : "border-gray-200 bg-white"
+                  }`}
+                >
+                  <Image
+                    src={`data:${enhancedImageMimeType};base64,${enhancedImageBase64}`}
+                    alt=""
+                    width={320}
+                    height={200}
+                    unoptimized
+                    className="mb-2 aspect-[1.6] w-full rounded object-cover"
+                  />
+                  <span className="text-sm font-medium">
+                    {t("enhancedImage")}
+                  </span>
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setImageVariant("original")}
+                  className={`rounded-md border p-2 text-left transition ${
+                    imageVariant === "original"
+                      ? "border-blue-500 bg-blue-50"
+                      : "border-gray-200 bg-white"
+                  }`}
+                >
+                  <Image
+                    src={`data:${imageMimeType};base64,${imageBase64}`}
+                    alt=""
+                    width={320}
+                    height={200}
+                    unoptimized
+                    className="mb-2 aspect-[1.6] w-full rounded object-cover"
+                  />
+                  <span className="text-sm font-medium">
+                    {t("originalImage")}
+                  </span>
+                </button>
+              </div>
+            </div>
+          )}
+
           {/* 名前 */}
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             <div className="space-y-2">
@@ -125,7 +223,7 @@ const ContactForm: React.FC<ContactFormProps> = ({
                 id="lastName"
                 value={formData.lastName}
                 onChange={handleChange("lastName")}
-                placeholder="山田"
+                placeholder={t("lastNamePlaceholder")}
               />
             </div>
             <div className="space-y-2">
@@ -134,7 +232,7 @@ const ContactForm: React.FC<ContactFormProps> = ({
                 id="firstName"
                 value={formData.firstName}
                 onChange={handleChange("firstName")}
-                placeholder="太郎"
+                placeholder={t("firstNamePlaceholder")}
               />
             </div>
           </div>
@@ -152,7 +250,7 @@ const ContactForm: React.FC<ContactFormProps> = ({
                 id="phoneticLastName"
                 value={formData.phoneticLastName}
                 onChange={handleChange("phoneticLastName")}
-                placeholder="やまだ"
+                placeholder={t("phoneticLastNamePlaceholder")}
               />
             </div>
             <div className="space-y-2">
@@ -166,7 +264,7 @@ const ContactForm: React.FC<ContactFormProps> = ({
                 id="phoneticFirstName"
                 value={formData.phoneticFirstName}
                 onChange={handleChange("phoneticFirstName")}
-                placeholder="たろう"
+                placeholder={t("phoneticFirstNamePlaceholder")}
               />
             </div>
           </div>
@@ -346,7 +444,9 @@ const ContactForm: React.FC<ContactFormProps> = ({
           {/* アクションボタン */}
           <div className="flex flex-col sm:flex-row gap-3 pt-4 border-t">
             <Button
-              onClick={() => onSave(formData)}
+              onClick={() =>
+                onSave(formData, selectedImageBase64, selectedImageMimeType)
+              }
               className="flex-1 h-12 text-base touch-manipulation"
             >
               💾 {t("saveVCard")}

--- a/src/components/business-card/ImageSelector.tsx
+++ b/src/components/business-card/ImageSelector.tsx
@@ -3,12 +3,13 @@
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { useLanguage } from "@/contexts/LanguageContext";
-import { Camera, Upload } from "lucide-react";
-import React, { useRef } from "react";
+import { inspectBusinessCardImage } from "@/services/business-card/imageEnhancement";
+import { AlertTriangle, Camera, Upload } from "lucide-react";
+import React, { useRef, useState } from "react";
 // heic2any is imported dynamically to avoid SSR issues
 
 interface ImageSelectorProps {
-  onImageSelected: (file: File) => void;
+  onImageSelected: (file: File, warnings: string[]) => void;
   error: string | null;
 }
 
@@ -156,6 +157,7 @@ const ImageSelector: React.FC<ImageSelectorProps> = ({
   const fileInputRef = useRef<HTMLInputElement>(null);
   const cameraInputRef = useRef<HTMLInputElement>(null);
   const { t } = useLanguage();
+  const [qualityWarnings, setQualityWarnings] = useState<string[]>([]);
 
   const handleFileChange = async (
     event: React.ChangeEvent<HTMLInputElement>,
@@ -231,13 +233,18 @@ const ImageSelector: React.FC<ImageSelectorProps> = ({
         return;
       }
 
+      const qualityResult = await inspectBusinessCardImage(file, t);
+      const warnings = qualityResult.warnings;
+      setQualityWarnings(warnings);
+
       console.log("📁 File selected:", {
         name: file.name,
         type: file.type,
         size: `${(file.size / (1024 * 1024)).toFixed(1)}MB`,
+        dimensions: `${qualityResult.width}x${qualityResult.height}`,
       });
 
-      onImageSelected(file);
+      onImageSelected(file, warnings);
     } else {
       alert(t("selectImageFile"));
     }
@@ -290,6 +297,19 @@ const ImageSelector: React.FC<ImageSelectorProps> = ({
           </div>
         )}
 
+        {qualityWarnings.length > 0 && (
+          <div className="bg-amber-50 border border-amber-200 text-amber-800 px-4 py-3 rounded-lg">
+            <div className="flex items-start gap-2">
+              <AlertTriangle className="h-4 w-4 mt-0.5 flex-shrink-0" />
+              <div className="text-sm space-y-1">
+                {qualityWarnings.map((warning) => (
+                  <p key={warning}>{warning}</p>
+                ))}
+              </div>
+            </div>
+          </div>
+        )}
+
         {/* カメラ用のinput */}
         <input
           ref={cameraInputRef}
@@ -315,6 +335,10 @@ const ImageSelector: React.FC<ImageSelectorProps> = ({
             <p>• {t("photoTipBrightArea")}</p>
             <p>• {t("photoTipCaptureEntire")}</p>
             <p>• {t("photoTipFocus")}</p>
+            <p>• {t("photoTipSmallCard")}</p>
+            <p>• {t("photoTipRoundedCorners")}</p>
+            <p>• {t("photoTipHighResolution")}</p>
+            <p>• {t("photoTipCardService")}</p>
           </div>
         </div>
       </div>

--- a/src/components/simple-editor/BackgroundCustomizer.tsx
+++ b/src/components/simple-editor/BackgroundCustomizer.tsx
@@ -3,7 +3,7 @@ import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { ImageUploader } from "./ImageUploader";
-import { Palette, Sparkles, Image } from "lucide-react";
+import { Palette, Sparkles, Image as ImageIcon } from "lucide-react";
 import { useLanguage } from "@/contexts/LanguageContext";
 
 interface BackgroundCustomizerProps {
@@ -70,7 +70,7 @@ export function BackgroundCustomizer({
             {t("gradientShort")}
           </TabsTrigger>
           <TabsTrigger value="image" className="text-xs">
-            <Image className="w-4 h-4 mr-1" />
+            <ImageIcon className="w-4 h-4 mr-1" />
             {t("backgroundImageTab")}
           </TabsTrigger>
         </TabsList>

--- a/src/components/simple-editor/CollapsibleComponentList.tsx
+++ b/src/components/simple-editor/CollapsibleComponentList.tsx
@@ -6,7 +6,7 @@ import {
   ChevronUp,
   User,
   FileText,
-  Image,
+  Image as ImageIcon,
   Link,
 } from "lucide-react";
 import { ProfileComponent } from "./utils/dataStructure";
@@ -140,7 +140,7 @@ export function CollapsibleComponentList({
       {groupedComponents.image.length > 0 && (
         <CollapsibleSection
           title={`${t("imageSection")} (${groupedComponents.image.length})`}
-          icon={<Image className="h-5 w-5 text-gray-600" />}
+          icon={<ImageIcon className="h-5 w-5 text-gray-600" />}
           defaultExpanded={false}
         >
           <div className="space-y-2">

--- a/src/components/simple-editor/ComponentEditor.tsx
+++ b/src/components/simple-editor/ComponentEditor.tsx
@@ -12,6 +12,7 @@ import { ImageUploader } from "./ImageUploader";
 import { getSocialServiceInfo } from "@/utils/socialLinks";
 import { useEffect } from "react";
 import { useLanguage } from "@/contexts/LanguageContext";
+import { BIO_MAX_LENGTH, BIO_WARNING_THRESHOLD } from "@/lib/constants/profile";
 
 interface ComponentEditorProps {
   component: ProfileComponent;
@@ -483,7 +484,7 @@ function ProfileEditor({
                 onChange={(e) =>
                   setProfileData({ ...profileData, lastName: e.target.value })
                 }
-                placeholder="山田"
+                placeholder={t("lastNamePlaceholder")}
                 className="mt-1"
               />
             </div>
@@ -497,7 +498,7 @@ function ProfileEditor({
                 onChange={(e) =>
                   setProfileData({ ...profileData, firstName: e.target.value })
                 }
-                placeholder="太郎"
+                placeholder={t("firstNamePlaceholder")}
                 className="mt-1"
               />
             </div>
@@ -517,7 +518,7 @@ function ProfileEditor({
                     phoneticLastName: e.target.value,
                   })
                 }
-                placeholder="yamada"
+                placeholder={t("phoneticLastNamePlaceholder")}
                 className="mt-1"
               />
             </div>
@@ -534,7 +535,7 @@ function ProfileEditor({
                     phoneticFirstName: e.target.value,
                   })
                 }
-                placeholder="taro"
+                placeholder={t("phoneticFirstNamePlaceholder")}
                 className="mt-1"
               />
             </div>
@@ -550,10 +551,27 @@ function ProfileEditor({
               onChange={(e) =>
                 setProfileData({ ...profileData, bio: e.target.value })
               }
+              maxLength={BIO_MAX_LENGTH}
               rows={3}
               placeholder={t("briefIntroduction")}
               className="mt-1"
             />
+            <div className="mt-1 flex items-center justify-between text-xs">
+              <span
+                className={
+                  (profileData.bio || "").length >= BIO_WARNING_THRESHOLD
+                    ? "text-amber-600"
+                    : "text-gray-500"
+                }
+              >
+                {(profileData.bio || "").length >= BIO_WARNING_THRESHOLD
+                  ? t("bioLimitWarning")
+                  : ""}
+              </span>
+              <span className="text-gray-500">
+                {(profileData.bio || "").length} / {BIO_MAX_LENGTH}
+              </span>
+            </div>
           </div>
 
           {/* 写真アップロード */}

--- a/src/components/simple-editor/SimplePageEditor.tsx
+++ b/src/components/simple-editor/SimplePageEditor.tsx
@@ -48,6 +48,7 @@ import { ComponentEditor } from "./ComponentEditor";
 import { BackgroundCustomizer } from "./BackgroundCustomizer";
 import { DevicePreview } from "./DevicePreview";
 import { cleanupProfileData } from "@/utils/cleanupProfileData";
+import { getUidFallbackUsername } from "@/lib/username";
 
 // ドラッグ可能なコンポーネントアイテム
 function SortableItem({ component, onDelete, onEdit }: SortableItemProps) {
@@ -666,7 +667,7 @@ export function SimplePageEditor({
           {/* デバイスプレビューモーダル */}
           {showDevicePreview && (
             <DevicePreview
-              profileUrl={`/p/${user?.username || user?.email?.split("@")[0] || "preview"}`}
+              profileUrl={`/p/${user?.username || getUidFallbackUsername(userId)}`}
               components={components}
               background={background}
               onClose={() => setShowDevicePreview(false)}

--- a/src/components/simple-editor/utils/validation.ts
+++ b/src/components/simple-editor/utils/validation.ts
@@ -1,6 +1,7 @@
 // src/components/simple-editor/utils/validation.ts
 import { z } from "zod";
 import DOMPurify from "isomorphic-dompurify";
+import { BIO_MAX_LENGTH } from "@/lib/constants/profile";
 
 // Configure DOMPurify to remove all HTML tags and keep only text
 const sanitizeString = (str: string): string => {
@@ -79,7 +80,7 @@ export const ProfileContentSchema = z.object({
   address: z.string().max(500).transform(sanitizeString).optional(),
   city: z.string().max(200).transform(sanitizeString).optional(),
   postalCode: z.string().max(20).transform(sanitizeString).optional(),
-  bio: z.string().max(1000).transform(sanitizeString).optional(),
+  bio: z.string().max(BIO_MAX_LENGTH).transform(sanitizeString).optional(),
   photoURL: z
     .string()
     .refine(

--- a/src/contexts/AuthContext.test.tsx
+++ b/src/contexts/AuthContext.test.tsx
@@ -309,6 +309,16 @@ describe("AuthContext", () => {
         displayName: "New User",
       });
       expect(firebaseAuth.sendEmailVerification).toHaveBeenCalledWith(mockUser);
+      expect(firestore.setDoc).toHaveBeenCalledWith(
+        { id: "test-doc" },
+        expect.objectContaining({
+          username: expect.stringMatching(/^user_[a-f0-9]{16}$/),
+        }),
+      );
+      expect(firestore.setDoc).not.toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ username: "newuser" }),
+      );
       expect(mockPush).toHaveBeenCalledWith("/dashboard");
     });
 

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -2,6 +2,10 @@
 
 import { auth, db } from "@/lib/firebase";
 import {
+  generateDefaultUsername,
+  getUidFallbackUsername,
+} from "@/lib/username";
+import {
   AuthError,
   GoogleAuthProvider,
   User,
@@ -129,7 +133,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
         // 新規ユーザーの場合
         await setDoc(userRef, {
           ...userData,
-          username: user.email?.split("@")[0] || `user_${user.uid.slice(0, 8)}`,
+          username: generateDefaultUsername(),
           createdAt: serverTimestamp(),
           name: user.displayName || "",
           bio: "",
@@ -148,7 +152,17 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
         // New user document created
       } else {
         // 既存ユーザーの場合は更新
-        await setDoc(userRef, userData, { merge: true });
+        const existingData = userSnap.data();
+        await setDoc(
+          userRef,
+          {
+            ...userData,
+            ...(!existingData.username
+              ? { username: getUidFallbackUsername(user.uid) }
+              : {}),
+          },
+          { merge: true },
+        );
         // User document updated
       }
     } catch (error) {

--- a/src/contexts/LanguageContext.tsx
+++ b/src/contexts/LanguageContext.tsx
@@ -107,6 +107,15 @@ const translations = {
     photoTipBrightArea: "明るい場所で撮影",
     photoTipCaptureEntire: "名刺全体を画面に収める",
     photoTipFocus: "ピントを合わせて撮影",
+    photoTipSmallCard: "小さいカードは読み取り精度が下がる場合があります",
+    photoTipRoundedCorners: "角丸カードは四隅が欠けないよう余白を入れて撮影",
+    photoTipHighResolution: "高解像度の画像（推奨: 1000px以上）を使用",
+    photoTipCardService:
+      "名刺サービスのミニカードは大きく、正面から撮影してください",
+    imageQualityLowResolution:
+      "画像の解像度が低めです。1000px以上の画像を推奨します。",
+    imageQualityAspectRatio:
+      "名刺らしい縦横比から外れています。余白や傾きを確認してください。",
     confirmAndEdit: "情報の確認・編集",
     phoneticReading: "ふりがな",
     labelExample: "ラベル (例: 本社)",
@@ -117,6 +126,9 @@ const translations = {
     other: "その他",
     addPhoneNumber: "電話番号を追加",
     vcardPreview: "vCard プレビュー",
+    vcardImageChoice: "連絡先に保存する画像",
+    enhancedImage: "補正画像",
+    originalImage: "元画像",
     saveVCard: "vCardを保存",
     failedToAnalyzeCard: "名刺の解析に失敗しました",
 
@@ -152,6 +164,11 @@ const translations = {
     websitePlaceholder: "https://example.com",
     addressPlaceholder: "東京都渋谷区...",
     bioPlaceholder: "あなたについて教えてください...",
+    bioLimitWarning: "文字数上限に近づいています",
+    lastNamePlaceholder: "山田",
+    firstNamePlaceholder: "太郎",
+    phoneticLastNamePlaceholder: "やまだ",
+    phoneticFirstNamePlaceholder: "たろう",
 
     // SimplePageEditor
     profileEditor: "プロフィール編集",
@@ -427,6 +444,14 @@ const translations = {
     photoTipBrightArea: "Take photo in bright area",
     photoTipCaptureEntire: "Capture entire business card",
     photoTipFocus: "Take photo with focus",
+    photoTipSmallCard: "Small cards may reduce OCR accuracy",
+    photoTipRoundedCorners: "Leave margin around rounded card corners",
+    photoTipHighResolution: "Use a high-resolution image (1000px+ recommended)",
+    photoTipCardService: "For mini cards, shoot close-up and straight on",
+    imageQualityLowResolution:
+      "This image looks low resolution. Use 1000px or larger when possible.",
+    imageQualityAspectRatio:
+      "The aspect ratio is unusual for a business card. Check margins and tilt.",
     confirmAndEdit: "Confirm and Edit Information",
     phoneticReading: "phonetic",
     labelExample: "Label (e.g. Head Office)",
@@ -437,6 +462,9 @@ const translations = {
     other: "Other",
     addPhoneNumber: "Add Phone Number",
     vcardPreview: "vCard Preview",
+    vcardImageChoice: "Image saved to contact",
+    enhancedImage: "Enhanced",
+    originalImage: "Original",
     saveVCard: "Save vCard",
     failedToAnalyzeCard: "Failed to analyze business card",
 
@@ -471,6 +499,11 @@ const translations = {
     websitePlaceholder: "https://example.com",
     addressPlaceholder: "123 Main St, New York...",
     bioPlaceholder: "Tell us about yourself...",
+    bioLimitWarning: "Approaching the character limit",
+    lastNamePlaceholder: "Smith",
+    firstNamePlaceholder: "John",
+    phoneticLastNamePlaceholder: "smith",
+    phoneticFirstNamePlaceholder: "john",
 
     // SimplePageEditor
     profileEditor: "Profile Editor",

--- a/src/lib/admin.ts
+++ b/src/lib/admin.ts
@@ -1,0 +1,40 @@
+import { adminAuth } from "@/lib/firebase-admin";
+import type { NextRequest } from "next/server";
+
+function parseAdminList(value: string | undefined): string[] {
+  return (value || "")
+    .split(",")
+    .map((item) => item.trim().toLowerCase())
+    .filter(Boolean);
+}
+
+export async function verifyAdminRequest(request: NextRequest) {
+  const authorization = request.headers.get("authorization");
+  const idToken = authorization?.startsWith("Bearer ")
+    ? authorization.slice("Bearer ".length)
+    : null;
+
+  if (!idToken) {
+    return { ok: false as const, status: 401, error: "Unauthorized" };
+  }
+
+  let decodedToken;
+  try {
+    decodedToken = await adminAuth.verifyIdToken(idToken);
+  } catch {
+    return { ok: false as const, status: 401, error: "Unauthorized" };
+  }
+  const adminEmails = parseAdminList(process.env.ADMIN_EMAILS);
+  const adminUids = parseAdminList(process.env.ADMIN_UIDS);
+  const email = decodedToken.email?.toLowerCase();
+  const uid = decodedToken.uid.toLowerCase();
+
+  if (
+    (email && adminEmails.includes(email)) ||
+    (uid && adminUids.includes(uid))
+  ) {
+    return { ok: true as const, decodedToken };
+  }
+
+  return { ok: false as const, status: 403, error: "Forbidden" };
+}

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -35,9 +35,17 @@ export async function trackPageView(username: string) {
     const usersRef = collection(db, "users");
     const q = query(usersRef, where("username", "==", username));
     const snapshot = await getDocs(q);
+    let userId = snapshot.docs[0]?.id;
 
-    if (!snapshot.empty) {
-      const userId = snapshot.docs[0].id;
+    if (!userId && username.startsWith("u_")) {
+      const uid = username.slice(2);
+      const userDoc = await getDoc(doc(db, "users", uid));
+      if (userDoc.exists()) {
+        userId = uid;
+      }
+    }
+
+    if (userId) {
       const today = new Date().toISOString().split("T")[0]; // "2025-09-19"
 
       const userDoc = await getDoc(doc(db, "users", userId));

--- a/src/lib/constants/profile.ts
+++ b/src/lib/constants/profile.ts
@@ -1,0 +1,2 @@
+export const BIO_MAX_LENGTH = 500;
+export const BIO_WARNING_THRESHOLD = 450;

--- a/src/lib/firebase-admin.ts
+++ b/src/lib/firebase-admin.ts
@@ -1,6 +1,7 @@
 import { initializeApp, getApps, cert } from "firebase-admin/app";
 import { getFirestore } from "firebase-admin/firestore";
 import { getAuth } from "firebase-admin/auth";
+import { generateDefaultUsername } from "./username";
 
 // Initialize Firebase Admin
 if (!getApps().length) {
@@ -74,13 +75,11 @@ export async function createUserDocument(userData: {
   const userDoc = {
     uid: userData.uid,
     email: userData.email,
-    username: userData.username || userData.email.split("@")[0],
+    username: userData.username || generateDefaultUsername(),
     createdAt: new Date(),
     updatedAt: new Date(),
     profile: {
-      name:
-        `${userData.firstName || ""} ${userData.lastName || ""}`.trim() ||
-        userData.email.split("@")[0],
+      name: `${userData.firstName || ""} ${userData.lastName || ""}`.trim(),
       links: [],
     },
     cards: [],

--- a/src/lib/username.test.ts
+++ b/src/lib/username.test.ts
@@ -1,0 +1,22 @@
+import { generateDefaultUsername, getUidFallbackUsername } from "./username";
+
+describe("generateDefaultUsername", () => {
+  it("メールアドレス由来ではない公開ユーザー名を生成する", () => {
+    const username = generateDefaultUsername();
+
+    expect(username).toMatch(/^user_[a-f0-9]{16}$/);
+    expect(username).not.toContain("@");
+  });
+});
+
+describe("getUidFallbackUsername", () => {
+  it("username未設定ユーザー向けに安定したUID由来のフォールバックを返す", () => {
+    expect(getUidFallbackUsername("abc123XYZ_4567890-long-uid")).toBe(
+      "u_abc123XYZ_4567890-long-uid",
+    );
+  });
+
+  it("URLに使える文字だけに正規化する", () => {
+    expect(getUidFallbackUsername("abc@example.com")).toBe("u_abcexamplecom");
+  });
+});

--- a/src/lib/username.ts
+++ b/src/lib/username.ts
@@ -1,0 +1,32 @@
+const USERNAME_RANDOM_BYTES = 8;
+
+function randomBytes(length: number): Uint8Array {
+  const bytes = new Uint8Array(length);
+  const cryptoApi = globalThis.crypto;
+
+  if (cryptoApi?.getRandomValues) {
+    cryptoApi.getRandomValues(bytes);
+    return bytes;
+  }
+
+  for (let i = 0; i < bytes.length; i += 1) {
+    bytes[i] = Math.floor(Math.random() * 256);
+  }
+
+  return bytes;
+}
+
+function toHex(bytes: Uint8Array): string {
+  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join(
+    "",
+  );
+}
+
+export function generateDefaultUsername(): string {
+  return `user_${toHex(randomBytes(USERNAME_RANDOM_BYTES))}`;
+}
+
+export function getUidFallbackUsername(uid: string): string {
+  const normalizedUid = uid.replace(/[^a-zA-Z0-9_-]/g, "");
+  return normalizedUid ? `u_${normalizedUid}` : generateDefaultUsername();
+}

--- a/src/services/business-card/imageEnhancement.ts
+++ b/src/services/business-card/imageEnhancement.ts
@@ -1,0 +1,100 @@
+export interface ImageQualityResult {
+  width: number;
+  height: number;
+  warnings: string[];
+}
+
+export interface EnhancedImageResult {
+  dataUrl: string;
+  base64: string;
+  mimeType: string;
+}
+
+const RECOMMENDED_MIN_SIDE = 1000;
+const MIN_BUSINESS_CARD_RATIO = 1.35;
+const MAX_BUSINESS_CARD_RATIO = 1.95;
+
+function loadImageFromSource(source: File | string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    const objectUrl =
+      typeof source === "string" ? null : URL.createObjectURL(source);
+
+    img.onload = () => {
+      if (objectUrl) {
+        URL.revokeObjectURL(objectUrl);
+      }
+      resolve(img);
+    };
+    img.onerror = () => {
+      if (objectUrl) {
+        URL.revokeObjectURL(objectUrl);
+      }
+      reject(new Error("Failed to load image"));
+    };
+    img.src = objectUrl || (source as string);
+  });
+}
+
+export async function inspectBusinessCardImage(
+  file: File,
+  t: (key: string) => string,
+): Promise<ImageQualityResult> {
+  const img = await loadImageFromSource(file);
+  const width = img.naturalWidth || img.width;
+  const height = img.naturalHeight || img.height;
+  const longSide = Math.max(width, height);
+  const shortSide = Math.min(width, height);
+  const ratio = longSide / Math.max(shortSide, 1);
+  const warnings: string[] = [];
+
+  if (longSide < RECOMMENDED_MIN_SIDE || shortSide < 600) {
+    warnings.push(t("imageQualityLowResolution"));
+  }
+
+  if (ratio < MIN_BUSINESS_CARD_RATIO || ratio > MAX_BUSINESS_CARD_RATIO) {
+    warnings.push(t("imageQualityAspectRatio"));
+  }
+
+  return { width, height, warnings };
+}
+
+export async function enhanceBusinessCardImage(
+  dataUrl: string,
+): Promise<EnhancedImageResult> {
+  const img = await loadImageFromSource(dataUrl);
+  const canvas = document.createElement("canvas");
+  const ctx = canvas.getContext("2d", { willReadFrequently: true });
+
+  if (!ctx) {
+    throw new Error("Canvas is unavailable");
+  }
+
+  canvas.width = img.naturalWidth || img.width;
+  canvas.height = img.naturalHeight || img.height;
+  ctx.fillStyle = "#ffffff";
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+  ctx.filter = "contrast(1.18) brightness(1.06) saturate(0.92)";
+  ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+
+  const imageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
+  const data = imageData.data;
+
+  for (let index = 0; index < data.length; index += 4) {
+    const average = (data[index] + data[index + 1] + data[index + 2]) / 3;
+    const boost = average > 210 ? 10 : average < 80 ? -8 : 0;
+    data[index] = Math.max(0, Math.min(255, data[index] + boost));
+    data[index + 1] = Math.max(0, Math.min(255, data[index + 1] + boost));
+    data[index + 2] = Math.max(0, Math.min(255, data[index + 2] + boost));
+  }
+
+  ctx.filter = "none";
+  ctx.putImageData(imageData, 0, 0);
+
+  const enhancedDataUrl = canvas.toDataURL("image/jpeg", 0.9);
+  return {
+    dataUrl: enhancedDataUrl,
+    base64: enhancedDataUrl.split(",")[1],
+    mimeType: "image/jpeg",
+  };
+}


### PR DESCRIPTION
## Summary
- Release the profile privacy fix that stops deriving public usernames from email local parts for new registrations.
- Preserve existing public URLs, add UID fallback routing, and add admin-only rotation for already exposed email-derived usernames.
- Release the business-card scan and editor UX fixes: bio length feedback, localized placeholders, scan quality tips/warnings, enhanced image generation, and original/enhanced image selection.
- Remove the remaining JSX image alt lint warnings by aliasing lucide image icons.

## Issue Coverage
Closes #50
Closes #51
Closes #52
Closes #53

Issue #54 was not found as an issue via the GitHub API, so it is not referenced with a closing keyword.

## Validation
Local validation before merging into `dev`:
- `npm run lint` -> no warnings or errors
- `npm run type-check`
- `npm test`
- `npm run build`
- `npm run test:e2e -- --project=chromium e2e/auth.spec.ts --grep "ランディングページ"`

Remote validation on PR #54 into `dev`:
- Lint and Type Check
- Security Scan
- Build Application
- Merge Readiness Check
- Vercel deployment
- Claude review