### PR TITLE
Fix self-service username randomization

### DIFF
--- a/src/app/api/users/me/rotate-username/route.ts
+++ b/src/app/api/users/me/rotate-username/route.ts
@@ -1,0 +1,81 @@
+import { adminDb, verifyIdToken } from "@/lib/firebase-admin";
+import { generateDefaultUsername } from "@/lib/username";
+import { FieldValue } from "firebase-admin/firestore";
+import { NextRequest, NextResponse } from "next/server";
+
+async function generateUniqueUsername() {
+  for (let attempt = 0; attempt < 8; attempt += 1) {
+    const username = generateDefaultUsername();
+    const snapshot = await adminDb
+      .collection("users")
+      .where("username", "==", username)
+      .limit(1)
+      .get();
+
+    if (snapshot.empty) {
+      return username;
+    }
+  }
+
+  throw new Error("Failed to generate unique username");
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const authHeader = request.headers.get("authorization");
+    const token = authHeader?.startsWith("Bearer ")
+      ? authHeader.slice("Bearer ".length)
+      : null;
+
+    if (!token) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const verification = await verifyIdToken(token);
+    if (!verification.success || !verification.uid) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const userRef = adminDb.collection("users").doc(verification.uid);
+    const username = await generateUniqueUsername();
+    const result = await adminDb.runTransaction(async (transaction) => {
+      const userDoc = await transaction.get(userRef);
+      if (!userDoc.exists) {
+        return null;
+      }
+
+      const data = userDoc.data() || {};
+      const previousUsername = data.username || "";
+      const updateData: Record<string, unknown> = {
+        username,
+        usernameRotatedAt: FieldValue.serverTimestamp(),
+        usernameRotatedBy: verification.uid,
+        usernameRotatedBySelf: true,
+        updatedAt: FieldValue.serverTimestamp(),
+      };
+
+      if (previousUsername) {
+        updateData.previousUsernames = FieldValue.arrayUnion(previousUsername);
+      }
+
+      transaction.update(userRef, updateData);
+
+      return {
+        previousUsername,
+        username,
+      };
+    });
+
+    if (!result) {
+      return NextResponse.json({ error: "User not found" }, { status: 404 });
+    }
+
+    return NextResponse.json(result);
+  } catch (error) {
+    console.error("Self-service username rotation failed:", error);
+    return NextResponse.json(
+      { error: "Failed to rotate username" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/dashboard/edit/page.tsx
+++ b/src/app/dashboard/edit/page.tsx
@@ -18,7 +18,7 @@ import { BIO_MAX_LENGTH, BIO_WARNING_THRESHOLD } from "@/lib/constants/profile";
 import { db } from "@/lib/firebase";
 import { getUidFallbackUsername } from "@/lib/username";
 import { doc, getDoc, serverTimestamp, setDoc } from "firebase/firestore";
-import { Loader2, Palette, Save } from "lucide-react";
+import { Loader2, Palette, RefreshCw, Save } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
 
@@ -35,11 +35,12 @@ interface ProfileData {
 }
 
 export default function EditProfilePage() {
-  const { user, loading } = useAuth();
+  const { user, loading, getIdToken } = useAuth();
   const router = useRouter();
   const { t } = useLanguage();
   const [isLoading, setIsLoading] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
+  const [isRotatingUsername, setIsRotatingUsername] = useState(false);
   const [profile, setProfile] = useState<ProfileData>({
     name: "",
     username: "",
@@ -148,6 +149,48 @@ export default function EditProfilePage() {
     }
   };
 
+  const handleRotateUsername = async () => {
+    if (!user || isRotatingUsername) return;
+
+    const confirmed = window.confirm(t("randomUsernameConfirm"));
+    if (!confirmed) return;
+
+    setIsRotatingUsername(true);
+    try {
+      const token = await getIdToken();
+      if (!token) {
+        throw new Error("Missing ID token");
+      }
+
+      const response = await fetch("/api/users/me/rotate-username", {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      });
+
+      const data = await response.json();
+      if (!response.ok) {
+        throw new Error(data.error || "Failed to rotate username");
+      }
+
+      setProfile((prev) => ({ ...prev, username: data.username }));
+      toast({
+        title: t("success"),
+        description: t("randomUsernameUpdated"),
+      });
+    } catch (error) {
+      console.error("Error rotating username:", error);
+      toast({
+        title: t("error"),
+        description: t("randomUsernameUpdateError"),
+        variant: "destructive",
+      });
+    } finally {
+      setIsRotatingUsername(false);
+    }
+  };
+
   if (isLoading) {
     return (
       <div className="flex items-center justify-center min-h-screen">
@@ -187,14 +230,34 @@ export default function EditProfilePage() {
 
               <div className="space-y-2">
                 <Label htmlFor="username">{t("username")} *</Label>
-                <Input
-                  id="username"
-                  value={profile.username}
-                  onChange={(e) =>
-                    handleInputChange("username", e.target.value)
-                  }
-                  placeholder={t("usernamePlaceholder")}
-                />
+                <div className="flex flex-col sm:flex-row gap-2">
+                  <Input
+                    id="username"
+                    value={profile.username}
+                    onChange={(e) =>
+                      handleInputChange("username", e.target.value)
+                    }
+                    placeholder={t("usernamePlaceholder")}
+                    className="flex-1"
+                  />
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={handleRotateUsername}
+                    disabled={isRotatingUsername || isSaving}
+                    className="w-full sm:w-auto"
+                  >
+                    {isRotatingUsername ? (
+                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    ) : (
+                      <RefreshCw className="mr-2 h-4 w-4" />
+                    )}
+                    {t("useRandomUsername")}
+                  </Button>
+                </div>
+                <p className="text-xs text-muted-foreground">
+                  {t("randomUsernameHelp")}
+                </p>
                 <p className="text-xs text-muted-foreground">
                   {t("profileUrlPrefix")}: /p/{profile.username || "username"}
                 </p>

--- a/src/contexts/AuthContext.test.tsx
+++ b/src/contexts/AuthContext.test.tsx
@@ -312,7 +312,7 @@ describe("AuthContext", () => {
       expect(firestore.setDoc).toHaveBeenCalledWith(
         { id: "test-doc" },
         expect.objectContaining({
-          username: expect.stringMatching(/^user_[a-f0-9]{16}$/),
+          username: expect.stringMatching(/^[1-9][0-9]{11}$/),
         }),
       );
       expect(firestore.setDoc).not.toHaveBeenCalledWith(

--- a/src/contexts/LanguageContext.tsx
+++ b/src/contexts/LanguageContext.tsx
@@ -145,6 +145,13 @@ const translations = {
       "プロフィールページのデザインをカスタマイズできます",
     openDesignEditor: "デザインエディターを開く",
     usernameRequired: "ユーザー名は必須です",
+    useRandomUsername: "ランダムIDに変更",
+    randomUsernameHelp:
+      "メール由来のURLを公開したくない場合は、ランダムな数字IDに変更できます。",
+    randomUsernameConfirm:
+      "プロフィールURLをランダムな数字IDに変更します。現在のURLは使えなくなります。続行しますか？",
+    randomUsernameUpdated: "プロフィールURLをランダムIDに変更しました",
+    randomUsernameUpdateError: "プロフィールURLの変更に失敗しました",
     profileSaved: "プロフィールを保存しました",
     profileLoadError: "プロフィールの読み込みに失敗しました",
     profileSaveError: "プロフィールの保存に失敗しました",
@@ -156,7 +163,7 @@ const translations = {
 
     // Placeholders
     namePlaceholder: "山田 太郎",
-    usernamePlaceholder: "yamada_taro",
+    usernamePlaceholder: "123456789012",
     companyPlaceholder: "株式会社Example",
     positionPlaceholder: "営業部長",
     emailPlaceholder: "example@email.com",
@@ -480,6 +487,13 @@ const translations = {
     designCustomizationDescription: "Customize your profile page design",
     openDesignEditor: "Open Design Editor",
     usernameRequired: "Username is required",
+    useRandomUsername: "Use random ID",
+    randomUsernameHelp:
+      "Use a random numeric ID if you do not want an email-derived URL to remain public.",
+    randomUsernameConfirm:
+      "Change your profile URL to a random numeric ID? Your current URL will stop working.",
+    randomUsernameUpdated: "Profile URL changed to a random ID",
+    randomUsernameUpdateError: "Failed to change profile URL",
     profileSaved: "Profile saved successfully",
     profileLoadError: "Failed to load profile",
     profileSaveError: "Failed to save profile",
@@ -491,7 +505,7 @@ const translations = {
 
     // Placeholders
     namePlaceholder: "John Smith",
-    usernamePlaceholder: "john_smith",
+    usernamePlaceholder: "123456789012",
     companyPlaceholder: "Example Inc.",
     positionPlaceholder: "Sales Manager",
     emailPlaceholder: "example@email.com",

--- a/src/lib/username.test.ts
+++ b/src/lib/username.test.ts
@@ -1,10 +1,10 @@
 import { generateDefaultUsername, getUidFallbackUsername } from "./username";
 
 describe("generateDefaultUsername", () => {
-  it("メールアドレス由来ではない公開ユーザー名を生成する", () => {
+  it("メールアドレス由来ではないランダム数字IDを生成する", () => {
     const username = generateDefaultUsername();
 
-    expect(username).toMatch(/^user_[a-f0-9]{16}$/);
+    expect(username).toMatch(/^[1-9][0-9]{11}$/);
     expect(username).not.toContain("@");
   });
 });

--- a/src/lib/username.ts
+++ b/src/lib/username.ts
@@ -1,4 +1,4 @@
-const USERNAME_RANDOM_BYTES = 8;
+const USERNAME_RANDOM_DIGITS = 12;
 
 function randomBytes(length: number): Uint8Array {
   const bytes = new Uint8Array(length);
@@ -16,14 +16,12 @@ function randomBytes(length: number): Uint8Array {
   return bytes;
 }
 
-function toHex(bytes: Uint8Array): string {
-  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join(
-    "",
-  );
-}
-
 export function generateDefaultUsername(): string {
-  return `user_${toHex(randomBytes(USERNAME_RANDOM_BYTES))}`;
+  const bytes = randomBytes(USERNAME_RANDOM_DIGITS);
+  return Array.from(bytes, (byte, index) => {
+    const digit = byte % 10;
+    return index === 0 && digit === 0 ? "1" : String(digit);
+  }).join("");
 }
 
 export function getUidFallbackUsername(uid: string): string {


### PR DESCRIPTION
## Summary
- Add the missing self-service username rotation flow on `/dashboard/edit` so a signed-in user can change their own public profile URL to a random numeric ID.
- Add authenticated `POST /api/users/me/rotate-username`, scoped to the caller's Firebase UID, so users cannot rotate another user's username.
- Change the default public username generator from `user_<hex>` to a 12-digit random numeric ID for new users and all rotation flows.
- Preserve the UID fallback behavior for users with no stored username.

## What happened
The previous PR implemented new-user random username generation and an admin-only rotation path, but it did not implement the user-facing button/API for the account owner to rotate their own exposed URL. That was a requirements miss.

## Behavior after this PR
- Existing users keep their current URL until they choose to rotate it.
- A logged-in user can rotate their own URL from profile edit.
- Newly registered users receive a random numeric public ID, not an email-derived local part.
- Admin rotation still exists and now uses the same numeric generator.

## Validation
- `npm run lint`
- `npm run type-check`
- `npm test`
- `npm run build`