### PR TITLE
Enforce unique profile usernames

### DIFF
--- a/src/app/api/users/me/profile/route.ts
+++ b/src/app/api/users/me/profile/route.ts
@@ -1,0 +1,226 @@
+import { BIO_MAX_LENGTH } from "@/lib/constants/profile";
+import { adminDb, verifyIdToken } from "@/lib/firebase-admin";
+import { FieldValue } from "firebase-admin/firestore";
+import { NextRequest, NextResponse } from "next/server";
+
+const USERNAME_PATTERN = /^[a-z0-9][a-z0-9_-]{2,31}$/;
+
+const PROFILE_STRING_FIELDS = [
+  "name",
+  "bio",
+  "company",
+  "position",
+  "email",
+  "phone",
+  "website",
+  "address",
+] as const;
+
+function normalizeUsername(value: unknown) {
+  return typeof value === "string" ? value.trim().toLowerCase() : "";
+}
+
+function isReservedUsername(username: string) {
+  return username.startsWith("u_");
+}
+
+function isValidUsername(username: string) {
+  return USERNAME_PATTERN.test(username) && !isReservedUsername(username);
+}
+
+function pickString(value: unknown, maxLength = 200) {
+  return typeof value === "string" ? value.slice(0, maxLength) : "";
+}
+
+async function isUsernameAvailable(username: string, uid: string) {
+  const usernameKey = username.toLowerCase();
+  const reservation = await adminDb.collection("usernames").doc(usernameKey).get();
+  if (reservation.exists && reservation.data()?.uid !== uid) {
+    return false;
+  }
+
+  const snapshot = await adminDb
+    .collection("users")
+    .where("username", "==", username)
+    .limit(1)
+    .get();
+
+  return snapshot.empty || snapshot.docs[0].id === uid;
+}
+
+async function buildUsernameSuggestions(username: string, uid: string) {
+  const base = username.replace(/[^a-z0-9_-]/g, "").slice(0, 24) || "user";
+  const candidates = new Set<string>();
+
+  while (candidates.size < 8) {
+    const suffix = Math.floor(100 + Math.random() * 9000);
+    candidates.add(`${base}${suffix}`.slice(0, 32));
+  }
+
+  const available: string[] = [];
+  for (const candidate of candidates) {
+    if (isValidUsername(candidate) && (await isUsernameAvailable(candidate, uid))) {
+      available.push(candidate);
+    }
+    if (available.length >= 3) break;
+  }
+
+  return available;
+}
+
+export async function PATCH(request: NextRequest) {
+  try {
+    const authHeader = request.headers.get("authorization");
+    const token = authHeader?.startsWith("Bearer ")
+      ? authHeader.slice("Bearer ".length)
+      : null;
+
+    if (!token) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const verification = await verifyIdToken(token);
+    if (!verification.success || !verification.uid) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const body = await request.json();
+    const requestedUsername = normalizeUsername(body.username);
+    if (!requestedUsername) {
+      return NextResponse.json(
+        { error: "username_required" },
+        { status: 400 },
+      );
+    }
+
+    const userRef = adminDb.collection("users").doc(verification.uid);
+    const userDoc = await userRef.get();
+    const currentUsernameRaw =
+      typeof userDoc.data()?.username === "string" ? userDoc.data()?.username : "";
+    const currentUsername = normalizeUsername(currentUsernameRaw);
+    const isUsernameChanging = requestedUsername !== currentUsername;
+
+    if (isUsernameChanging && !isValidUsername(requestedUsername)) {
+      return NextResponse.json(
+        { error: "username_invalid" },
+        { status: 400 },
+      );
+    }
+
+    if (
+      isUsernameChanging &&
+      !(await isUsernameAvailable(requestedUsername, verification.uid))
+    ) {
+      const suggestions = await buildUsernameSuggestions(
+        requestedUsername,
+        verification.uid,
+      );
+      return NextResponse.json(
+        { error: "username_taken", suggestions },
+        { status: 409 },
+      );
+    }
+
+    const profileUpdates: Record<string, unknown> = {
+      uid: verification.uid,
+      username: isUsernameChanging
+        ? requestedUsername
+        : currentUsernameRaw || requestedUsername,
+      updatedAt: FieldValue.serverTimestamp(),
+    };
+
+    for (const field of PROFILE_STRING_FIELDS) {
+      profileUpdates[field] = pickString(
+        body[field],
+        field === "bio" ? BIO_MAX_LENGTH : 200,
+      );
+    }
+
+    await adminDb.runTransaction(async (transaction) => {
+      const latestUserDoc = await transaction.get(userRef);
+      const userExists = latestUserDoc.exists;
+
+      if (!isUsernameChanging) {
+        transaction.set(
+          userRef,
+          {
+            ...profileUpdates,
+            ...(!userExists ? { createdAt: FieldValue.serverTimestamp() } : {}),
+          },
+          { merge: true },
+        );
+        return;
+      }
+
+      const usernameRef = adminDb
+        .collection("usernames")
+        .doc(requestedUsername.toLowerCase());
+      const usernameDoc = await transaction.get(usernameRef);
+      if (usernameDoc.exists && usernameDoc.data()?.uid !== verification.uid) {
+        throw new Error("USERNAME_TAKEN");
+      }
+
+      const exactUsernameSnapshot = await transaction.get(
+        adminDb
+          .collection("users")
+          .where("username", "==", requestedUsername)
+          .limit(1),
+      );
+      if (
+        !exactUsernameSnapshot.empty &&
+        exactUsernameSnapshot.docs[0].id !== verification.uid
+      ) {
+        throw new Error("USERNAME_TAKEN");
+      }
+
+      const previousUsername = normalizeUsername(latestUserDoc.data()?.username);
+      if (previousUsername && previousUsername !== requestedUsername) {
+        const previousRef = adminDb
+          .collection("usernames")
+          .doc(previousUsername.toLowerCase());
+        const previousDoc = await transaction.get(previousRef);
+        if (previousDoc.exists && previousDoc.data()?.uid === verification.uid) {
+          transaction.delete(previousRef);
+        }
+        profileUpdates.previousUsernames =
+          FieldValue.arrayUnion(previousUsername);
+      }
+
+      transaction.set(usernameRef, {
+        uid: verification.uid,
+        username: requestedUsername,
+        updatedAt: FieldValue.serverTimestamp(),
+      });
+      transaction.set(
+        userRef,
+        {
+          ...profileUpdates,
+          ...(!userExists ? { createdAt: FieldValue.serverTimestamp() } : {}),
+        },
+        { merge: true },
+      );
+    });
+
+    return NextResponse.json({
+      profile: {
+        ...Object.fromEntries(
+          PROFILE_STRING_FIELDS.map((field) => [field, profileUpdates[field]]),
+        ),
+        username: profileUpdates.username,
+      },
+    });
+  } catch (error) {
+    if (error instanceof Error && error.message === "USERNAME_TAKEN") {
+      return NextResponse.json(
+        { error: "username_taken", suggestions: [] },
+        { status: 409 },
+      );
+    }
+
+    console.error("Profile update failed:", error);
+    return NextResponse.json(
+      { error: "profile_update_failed" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/dashboard/edit/page.tsx
+++ b/src/app/dashboard/edit/page.tsx
@@ -17,7 +17,7 @@ import { useLanguage } from "@/contexts/LanguageContext";
 import { BIO_MAX_LENGTH, BIO_WARNING_THRESHOLD } from "@/lib/constants/profile";
 import { db } from "@/lib/firebase";
 import { getUidFallbackUsername } from "@/lib/username";
-import { doc, getDoc, serverTimestamp, setDoc } from "firebase/firestore";
+import { doc, getDoc } from "firebase/firestore";
 import { Loader2, Palette, RefreshCw, Save } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
@@ -41,6 +41,7 @@ export default function EditProfilePage() {
   const [isLoading, setIsLoading] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
   const [isRotatingUsername, setIsRotatingUsername] = useState(false);
+  const [usernameSuggestions, setUsernameSuggestions] = useState<string[]>([]);
   const [profile, setProfile] = useState<ProfileData>({
     name: "",
     username: "",
@@ -101,6 +102,10 @@ export default function EditProfilePage() {
   }, [user, loading, router, loadProfile]);
 
   const handleInputChange = (field: keyof ProfileData, value: string) => {
+    if (field === "username") {
+      setUsernameSuggestions([]);
+    }
+
     setProfile((prev) => ({
       ...prev,
       [field]: value,
@@ -121,15 +126,47 @@ export default function EditProfilePage() {
 
     setIsSaving(true);
     try {
-      await setDoc(
-        doc(db, "users", user.uid),
-        {
-          ...profile,
-          uid: user.uid,
-          updatedAt: serverTimestamp(),
+      const token = await getIdToken();
+      if (!token) {
+        throw new Error("Missing ID token");
+      }
+
+      const response = await fetch("/api/users/me/profile", {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
         },
-        { merge: true },
-      );
+        body: JSON.stringify(profile),
+      });
+
+      const data = await response.json();
+      if (response.status === 409 && data.error === "username_taken") {
+        setUsernameSuggestions(Array.isArray(data.suggestions) ? data.suggestions : []);
+        toast({
+          title: t("error"),
+          description: t("usernameUnavailable"),
+          variant: "destructive",
+        });
+        return;
+      }
+
+      if (response.status === 400 && data.error === "username_invalid") {
+        toast({
+          title: t("error"),
+          description: t("usernameInvalid"),
+          variant: "destructive",
+        });
+        return;
+      }
+
+      if (!response.ok) {
+        throw new Error(data.error || "Failed to save profile");
+      }
+
+      if (data.profile?.username) {
+        setProfile((prev) => ({ ...prev, username: data.profile.username }));
+      }
 
       toast({
         title: t("success"),
@@ -175,6 +212,7 @@ export default function EditProfilePage() {
       }
 
       setProfile((prev) => ({ ...prev, username: data.username }));
+      setUsernameSuggestions([]);
       toast({
         title: t("success"),
         description: t("randomUsernameUpdated"),
@@ -261,6 +299,27 @@ export default function EditProfilePage() {
                 <p className="text-xs text-muted-foreground">
                   {t("profileUrlPrefix")}: /p/{profile.username || "username"}
                 </p>
+                {usernameSuggestions.length > 0 && (
+                  <div className="rounded-md border border-amber-200 bg-amber-50 p-3">
+                    <p className="text-xs font-medium text-amber-900">
+                      {t("usernameSuggestions")}
+                    </p>
+                    <div className="mt-2 flex flex-wrap gap-2">
+                      {usernameSuggestions.map((suggestion) => (
+                        <Button
+                          key={suggestion}
+                          type="button"
+                          variant="outline"
+                          size="sm"
+                          className="h-8 bg-white"
+                          onClick={() => handleInputChange("username", suggestion)}
+                        >
+                          {suggestion}
+                        </Button>
+                      ))}
+                    </div>
+                  </div>
+                )}
               </div>
 
               <div className="space-y-2">

--- a/src/contexts/LanguageContext.tsx
+++ b/src/contexts/LanguageContext.tsx
@@ -145,6 +145,11 @@ const translations = {
       "プロフィールページのデザインをカスタマイズできます",
     openDesignEditor: "デザインエディターを開く",
     usernameRequired: "ユーザー名は必須です",
+    usernameInvalid:
+      "ユーザー名は3〜32文字の英小文字・数字・ハイフン・アンダースコアで入力してください",
+    usernameUnavailable:
+      "このユーザー名は既に使われています。別のユーザー名を選択してください",
+    usernameSuggestions: "代わりに使える候補",
     useRandomUsername: "ランダムIDに変更",
     randomUsernameHelp:
       "メール由来のURLを公開したくない場合は、ランダムな数字IDに変更できます。",
@@ -487,6 +492,11 @@ const translations = {
     designCustomizationDescription: "Customize your profile page design",
     openDesignEditor: "Open Design Editor",
     usernameRequired: "Username is required",
+    usernameInvalid:
+      "Use 3-32 lowercase letters, numbers, hyphens, or underscores",
+    usernameUnavailable:
+      "This username is already taken. Choose a different username",
+    usernameSuggestions: "Available alternatives",
     useRandomUsername: "Use random ID",
     randomUsernameHelp:
       "Use a random numeric ID if you do not want an email-derived URL to remain public.",


### PR DESCRIPTION
## Summary
- Move profile saves from direct client Firestore writes to authenticated `PATCH /api/users/me/profile`.
- Validate manual username changes server-side before saving.
- Prevent duplicate usernames with both an exact users query and a `usernames/{username}` reservation document for concurrent conflicts.
- Return alternative username suggestions when the requested username is already taken.
- Show those suggestions in `/dashboard/edit` as selectable buttons.

## Behavior
- Saving an unchanged existing username still works, including legacy values.
- Changing to a duplicate username is rejected with `username_taken` and suggestions.
- Changing to an invalid username is rejected with `username_invalid`.
- New manual usernames are normalized to lowercase and must be 3-32 chars: lowercase letters, numbers, hyphen, underscore. `u_` remains reserved for UID fallback URLs.

## Validation
- `npm run lint`
- `npm run type-check`
- `npm test`
- `npm run build`