### PR TITLE
fix: Edit画面保存時にプロフィールコンポーネントへデータ同期

### DIFF
--- a/src/app/api/users/me/profile/route.ts
+++ b/src/app/api/users/me/profile/route.ts
@@ -209,6 +209,68 @@ export async function PATCH(request: NextRequest) {
       );
     });
 
+    const syncFields = [
+      "name",
+      "bio",
+      "company",
+      "position",
+      "email",
+      "phone",
+      "website",
+      "address",
+      "photoURL",
+    ] as const;
+
+    try {
+      const profileDocRef = adminDb
+        .collection("users")
+        .doc(verification.uid)
+        .collection("profile")
+        .doc("data");
+      const profileDoc = await profileDocRef.get();
+
+      if (profileDoc.exists) {
+        const profileData = profileDoc.data();
+        const components: any[] = profileData?.components || [];
+
+        const updatedComponents = components.map((comp: any) => {
+          if (comp.type !== "profile") return comp;
+
+          const existing = { ...(comp.content || {}) };
+          const nameParts = String(profileUpdates.name || "").split(" ");
+          const firstName =
+            nameParts.length > 1
+              ? nameParts.slice(1).join(" ")
+              : nameParts[0] || "";
+          const lastName = nameParts.length > 1 ? nameParts[0] : "";
+
+          const updated: Record<string, unknown> = { ...existing };
+
+          for (const field of syncFields) {
+            const value = profileUpdates[field];
+            if (typeof value === "string" && value !== "") {
+              updated[field] = value;
+            }
+          }
+
+          if (profileUpdates.name) {
+            updated.firstName = firstName;
+            updated.lastName = lastName;
+            updated.name = profileUpdates.name;
+          }
+
+          return { ...comp, content: updated };
+        });
+
+        await profileDocRef.update({
+          components: updatedComponents,
+          updatedAt: new Date(),
+        });
+      }
+    } catch (syncError) {
+      console.error("Profile component sync failed:", syncError);
+    }
+
     return NextResponse.json({
       profile: {
         ...Object.fromEntries(


### PR DESCRIPTION
## Summary

Edit画面で保存したプロフィール情報（名前、写真、会社、連絡先等）が、公開プロフィールページに反映されない問題を修正します。

### 原因
- Edit画面は `users/{userId}` ドキュメントに保存
- 公開ページは `users/{userId}/profile/data` サブコレクションのプロフィールコンポーネントを表示
- 2つのデータストア間に同期がなかった

### 修正内容
`PATCH /api/users/me/profile` のトランザクション完了後、`users/{userId}/profile/data` 内の `type: "profile"` コンポーネントに対して以下のフィールドを同期:
- name, bio, company, position, email, phone, website, address, photoURL
- nameから firstName/lastName も自動分割設定

同期失敗はログ出力のみでメイン処理は成功させる（非破壊的）。

### Test plan
- [ ] Edit画面でプロフィール情報を保存
- [ ] 公開プロフィールページに即座に反映されること
- [ ] プロフィールコンポーネントが存在しない場合はエラーにならないこと
- [ ] type-check / lint / build が通過すること