### PR TITLE
release: dev → main (プロフィールコンポーネント同期修正)

### DIFF
--- a/src/app/api/users/me/profile/route.ts
+++ b/src/app/api/users/me/profile/route.ts
@@ -209,6 +209,68 @@ export async function PATCH(request: NextRequest) {
       );
     });
 
+    const syncFields = [
+      "name",
+      "bio",
+      "company",
+      "position",
+      "email",
+      "phone",
+      "website",
+      "address",
+      "photoURL",
+    ] as const;
+
+    try {
+      const profileDocRef = adminDb
+        .collection("users")
+        .doc(verification.uid)
+        .collection("profile")
+        .doc("data");
+      const profileDoc = await profileDocRef.get();
+
+      if (profileDoc.exists) {
+        const profileData = profileDoc.data();
+        const components: any[] = profileData?.components || [];
+
+        const updatedComponents = components.map((comp: any) => {
+          if (comp.type !== "profile") return comp;
+
+          const existing = { ...(comp.content || {}) };
+          const nameParts = String(profileUpdates.name || "").split(" ");
+          const firstName =
+            nameParts.length > 1
+              ? nameParts.slice(1).join(" ")
+              : nameParts[0] || "";
+          const lastName = nameParts.length > 1 ? nameParts[0] : "";
+
+          const updated: Record<string, unknown> = { ...existing };
+
+          for (const field of syncFields) {
+            const value = profileUpdates[field];
+            if (typeof value === "string" && value !== "") {
+              updated[field] = value;
+            }
+          }
+
+          if (profileUpdates.name) {
+            updated.firstName = firstName;
+            updated.lastName = lastName;
+            updated.name = profileUpdates.name;
+          }
+
+          return { ...comp, content: updated };
+        });
+
+        await profileDocRef.update({
+          components: updatedComponents,
+          updatedAt: new Date(),
+        });
+      }
+    } catch (syncError) {
+      console.error("Profile component sync failed:", syncError);
+    }
+
     return NextResponse.json({
       profile: {
         ...Object.fromEntries(


### PR DESCRIPTION
## Summary

Edit画面で保存したプロフィール情報が公開ページに反映されるように、Firestore内のプロフィールコンポーネントへの同期処理を追加。

### 含まれる変更（前回リリース以降の全累積）
- プロフィール設定重複解消・レスポンシブ修正（PR #64, #65）
- Edit画面保存時にプロフィールコンポーネントへデータ同期（PR #66）

## Test plan
- [x] type-check / lint / build 全て通過
- [x] Vercel preview デプロイ成功
- [ ] Edit画面保存 → 公開ページ反映の確認