### PR TITLE
Improve profile ID setup and public profile performance

### DIFF
--- a/src/app/api/users/me/profile/route.ts
+++ b/src/app/api/users/me/profile/route.ts
@@ -1,5 +1,9 @@
 import { BIO_MAX_LENGTH } from "@/lib/constants/profile";
 import { adminDb, verifyIdToken } from "@/lib/firebase-admin";
+import {
+  generateDefaultUsername,
+  getUidFallbackUsername,
+} from "@/lib/username";
 import { FieldValue } from "firebase-admin/firestore";
 import { NextRequest, NextResponse } from "next/server";
 
@@ -25,8 +29,12 @@ function isReservedUsername(username: string) {
   return username.startsWith("u_");
 }
 
-function isValidUsername(username: string) {
-  return USERNAME_PATTERN.test(username) && !isReservedUsername(username);
+function isValidUsername(username: string, uid?: string) {
+  const ownUidUsername = uid ? getUidFallbackUsername(uid).toLowerCase() : "";
+  return (
+    USERNAME_PATTERN.test(username) &&
+    (!isReservedUsername(username) || username === ownUidUsername)
+  );
 }
 
 function pickString(value: unknown, maxLength = 200) {
@@ -64,7 +72,7 @@ async function buildUsernameSuggestions(username: string, uid: string) {
   const available: string[] = [];
   for (const candidate of candidates) {
     if (
-      isValidUsername(candidate) &&
+      isValidUsername(candidate, uid) &&
       (await isUsernameAvailable(candidate, uid))
     ) {
       available.push(candidate);
@@ -73,6 +81,17 @@ async function buildUsernameSuggestions(username: string, uid: string) {
   }
 
   return available;
+}
+
+async function generateUniqueUsername(uid: string) {
+  for (let attempt = 0; attempt < 8; attempt += 1) {
+    const username = generateDefaultUsername();
+    if (await isUsernameAvailable(username, uid)) {
+      return username;
+    }
+  }
+
+  throw new Error("Failed to generate unique username");
 }
 
 export async function PATCH(request: NextRequest) {
@@ -92,7 +111,15 @@ export async function PATCH(request: NextRequest) {
     }
 
     const body = await request.json();
-    const requestedUsername = normalizeUsername(body.username);
+    const usernameMode =
+      typeof body.usernameMode === "string" ? body.usernameMode : "custom";
+    const requestedUsername =
+      usernameMode === "random"
+        ? await generateUniqueUsername(verification.uid)
+        : usernameMode === "uid"
+          ? getUidFallbackUsername(verification.uid).toLowerCase()
+          : normalizeUsername(body.username);
+
     if (!requestedUsername) {
       return NextResponse.json({ error: "username_required" }, { status: 400 });
     }
@@ -106,7 +133,10 @@ export async function PATCH(request: NextRequest) {
     const currentUsername = normalizeUsername(currentUsernameRaw);
     const isUsernameChanging = requestedUsername !== currentUsername;
 
-    if (isUsernameChanging && !isValidUsername(requestedUsername)) {
+    if (
+      isUsernameChanging &&
+      !isValidUsername(requestedUsername, verification.uid)
+    ) {
       return NextResponse.json({ error: "username_invalid" }, { status: 400 });
     }
 
@@ -129,6 +159,7 @@ export async function PATCH(request: NextRequest) {
       username: isUsernameChanging
         ? requestedUsername
         : currentUsernameRaw || requestedUsername,
+      usernameConfirmed: true,
       updatedAt: FieldValue.serverTimestamp(),
     };
 

--- a/src/app/api/users/me/rotate-username/route.ts
+++ b/src/app/api/users/me/rotate-username/route.ts
@@ -6,6 +6,14 @@ import { NextRequest, NextResponse } from "next/server";
 async function generateUniqueUsername() {
   for (let attempt = 0; attempt < 8; attempt += 1) {
     const username = generateDefaultUsername();
+    const usernameDoc = await adminDb
+      .collection("usernames")
+      .doc(username.toLowerCase())
+      .get();
+    if (usernameDoc.exists) {
+      continue;
+    }
+
     const snapshot = await adminDb
       .collection("users")
       .where("username", "==", username)
@@ -46,8 +54,12 @@ export async function POST(request: NextRequest) {
 
       const data = userDoc.data() || {};
       const previousUsername = data.username || "";
+      const usernameRef = adminDb
+        .collection("usernames")
+        .doc(username.toLowerCase());
       const updateData: Record<string, unknown> = {
         username,
+        usernameConfirmed: true,
         usernameRotatedAt: FieldValue.serverTimestamp(),
         usernameRotatedBy: verification.uid,
         usernameRotatedBySelf: true,
@@ -56,8 +68,23 @@ export async function POST(request: NextRequest) {
 
       if (previousUsername) {
         updateData.previousUsernames = FieldValue.arrayUnion(previousUsername);
+        const previousRef = adminDb
+          .collection("usernames")
+          .doc(String(previousUsername).toLowerCase());
+        const previousDoc = await transaction.get(previousRef);
+        if (
+          previousDoc.exists &&
+          previousDoc.data()?.uid === verification.uid
+        ) {
+          transaction.delete(previousRef);
+        }
       }
 
+      transaction.set(usernameRef, {
+        uid: verification.uid,
+        username,
+        updatedAt: FieldValue.serverTimestamp(),
+      });
       transaction.update(userRef, updateData);
 
       return {

--- a/src/app/dashboard/edit/page.tsx
+++ b/src/app/dashboard/edit/page.tsx
@@ -50,6 +50,7 @@ export default function EditProfilePage() {
   const [isSaving, setIsSaving] = useState(false);
   const [isRotatingUsername, setIsRotatingUsername] = useState(false);
   const [usernameSuggestions, setUsernameSuggestions] = useState<string[]>([]);
+  const [originalUsername, setOriginalUsername] = useState("");
   const [profile, setProfile] = useState<ProfileData>({
     name: "",
     username: "",
@@ -130,6 +131,7 @@ export default function EditProfilePage() {
         address: src.address || "",
         photoURL: src.photoURL || "",
       });
+      setOriginalUsername(username);
     } catch (error) {
       console.error("Error loading profile:", error);
       toast({
@@ -170,6 +172,14 @@ export default function EditProfilePage() {
         description: t("usernameRequired"),
         variant: "destructive",
       });
+      return;
+    }
+
+    const usernameChanged =
+      originalUsername &&
+      profile.username.trim().toLowerCase() !==
+        originalUsername.trim().toLowerCase();
+    if (usernameChanged && !window.confirm(t("profileUrlChangeConfirm"))) {
       return;
     }
 
@@ -217,6 +227,7 @@ export default function EditProfilePage() {
 
       if (data.profile?.username) {
         setProfile((prev) => ({ ...prev, username: data.profile.username }));
+        setOriginalUsername(data.profile.username);
       }
 
       try {
@@ -259,7 +270,9 @@ export default function EditProfilePage() {
 
       toast({
         title: t("success"),
-        description: t("profileSaved"),
+        description: usernameChanged
+          ? t("profileUrlChangedWarning")
+          : t("profileSaved"),
       });
 
       router.push("/dashboard");
@@ -278,7 +291,7 @@ export default function EditProfilePage() {
   const handleRotateUsername = async () => {
     if (!user || isRotatingUsername) return;
 
-    const confirmed = window.confirm(t("randomUsernameConfirm"));
+    const confirmed = window.confirm(t("profileUrlChangeConfirm"));
     if (!confirmed) return;
 
     setIsRotatingUsername(true);
@@ -301,10 +314,11 @@ export default function EditProfilePage() {
       }
 
       setProfile((prev) => ({ ...prev, username: data.username }));
+      setOriginalUsername(data.username);
       setUsernameSuggestions([]);
       toast({
         title: t("success"),
-        description: t("randomUsernameUpdated"),
+        description: t("profileUrlChangedWarning"),
       });
     } catch (error) {
       console.error("Error rotating username:", error);
@@ -385,6 +399,27 @@ export default function EditProfilePage() {
                 <p className="text-xs text-muted-foreground">
                   {t("randomUsernameHelp")}
                 </p>
+                {user && (
+                  <div className="rounded-md border border-blue-100 bg-blue-50 p-3">
+                    <p className="text-xs text-blue-900">
+                      {t("profileIdEditHelp")}
+                    </p>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      className="mt-2 h-8 bg-white"
+                      onClick={() =>
+                        handleInputChange(
+                          "username",
+                          getUidFallbackUsername(user.uid).toLowerCase(),
+                        )
+                      }
+                    >
+                      {t("useUidUsername")}
+                    </Button>
+                  </div>
+                )}
                 <p className="text-xs text-muted-foreground">
                   {t("profileUrlPrefix")}: /p/{profile.username || "username"}
                 </p>

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -4,8 +4,10 @@ import { useAuth } from "@/contexts/AuthContext";
 import { useLanguage } from "@/contexts/LanguageContext";
 import { getAnalyticsSummary } from "@/lib/analytics";
 import { db } from "@/lib/firebase";
+import { getUidFallbackUsername } from "@/lib/username";
 import { doc, getDoc } from "firebase/firestore";
 import {
+  AlertCircle,
   Crown,
   ExternalLink,
   Eye,
@@ -35,6 +37,13 @@ export default function DashboardPage() {
   const [promoCodeLoading, setPromoCodeLoading] = useState(false);
   const [promoCodeError, setPromoCodeError] = useState("");
   const [promoCodeSuccess, setPromoCodeSuccess] = useState("");
+  const [idSetupMode, setIdSetupMode] = useState<"random" | "uid" | "custom">(
+    "random",
+  );
+  const [customUsername, setCustomUsername] = useState("");
+  const [idSetupLoading, setIdSetupLoading] = useState(false);
+  const [idSetupError, setIdSetupError] = useState("");
+  const [idSetupSuccess, setIdSetupSuccess] = useState("");
 
   const fetchUserProfile = useCallback(async () => {
     if (!user) return;
@@ -119,6 +128,69 @@ export default function DashboardPage() {
     }
   };
 
+  const handleProfileIdSetup = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!user) return;
+
+    setIdSetupError("");
+    setIdSetupSuccess("");
+
+    if (idSetupMode === "custom" && !customUsername.trim()) {
+      setIdSetupError(t("usernameRequired"));
+      return;
+    }
+
+    setIdSetupLoading(true);
+
+    try {
+      const idToken = await user.getIdToken();
+      const response = await fetch("/api/users/me/profile", {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${idToken}`,
+        },
+        body: JSON.stringify({
+          usernameMode: idSetupMode,
+          username: customUsername,
+          name: userProfile?.name || user.displayName || "",
+          bio: userProfile?.bio || "",
+          company: userProfile?.company || "",
+          position: userProfile?.position || "",
+          email: userProfile?.email || user.email || "",
+          phone: userProfile?.phone || "",
+          website: userProfile?.website || "",
+          address: userProfile?.address || "",
+          photoURL: userProfile?.photoURL || "",
+        }),
+      });
+
+      const data = await response.json();
+      if (response.status === 409 && data.error === "username_taken") {
+        setIdSetupError(t("usernameUnavailable"));
+        return;
+      }
+
+      if (response.status === 400 && data.error === "username_invalid") {
+        setIdSetupError(t("usernameInvalid"));
+        return;
+      }
+
+      if (!response.ok) {
+        throw new Error(data.error || "Failed to set profile ID");
+      }
+
+      setIdSetupSuccess(t("profileIdSetupSuccess"));
+      setCustomUsername("");
+      await fetchUserProfile();
+    } catch (error) {
+      console.error("Error setting profile ID:", error);
+      setIdSetupError(t("profileSaveError"));
+    } finally {
+      setIdSetupLoading(false);
+    }
+  };
+
   if (loading) {
     return (
       <div className="min-h-screen flex items-center justify-center">
@@ -182,6 +254,107 @@ export default function DashboardPage() {
           <div className="mb-4 p-3 bg-yellow-50 border border-yellow-200 rounded-lg">
             <p className="text-sm text-yellow-800">📝 {t("profileSetup")}</p>
           </div>
+        )}
+
+        {!profileLoading && userProfile?.usernameConfirmed !== true && (
+          <form
+            onSubmit={handleProfileIdSetup}
+            className="mb-6 p-4 bg-white rounded-lg shadow-sm border border-blue-200"
+          >
+            <div className="flex items-start gap-3 mb-4">
+              <div className="p-2 bg-blue-100 rounded-lg">
+                <AlertCircle className="w-5 h-5 text-blue-600" />
+              </div>
+              <div>
+                <h2 className="font-semibold text-gray-900">
+                  {t("profileIdSetupTitle")}
+                </h2>
+                <p className="text-sm text-gray-600 mt-1">
+                  {t("profileIdSetupDescription")}
+                </p>
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              {[
+                {
+                  mode: "random" as const,
+                  title: t("profileIdRandomTitle"),
+                  description: t("profileIdRandomDescription"),
+                  badge: t("recommended"),
+                },
+                {
+                  mode: "custom" as const,
+                  title: t("profileIdCustomTitle"),
+                  description: t("profileIdCustomDescription"),
+                  badge: "",
+                },
+                {
+                  mode: "uid" as const,
+                  title: t("profileIdUidTitle"),
+                  description: `${t("profileIdUidDescription")} /p/${getUidFallbackUsername(user.uid).toLowerCase()}`,
+                  badge: "",
+                },
+              ].map((option) => (
+                <button
+                  key={option.mode}
+                  type="button"
+                  onClick={() => setIdSetupMode(option.mode)}
+                  className={`w-full rounded-lg border p-3 text-left transition-colors ${
+                    idSetupMode === option.mode
+                      ? "border-blue-500 bg-blue-50"
+                      : "border-gray-200 bg-white hover:bg-gray-50"
+                  }`}
+                >
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="text-sm font-medium text-gray-900">
+                      {option.title}
+                    </span>
+                    {option.badge && (
+                      <span className="rounded-full bg-blue-600 px-2 py-0.5 text-xs font-semibold text-white">
+                        {option.badge}
+                      </span>
+                    )}
+                  </div>
+                  <p className="mt-1 text-xs text-gray-600">
+                    {option.description}
+                  </p>
+                </button>
+              ))}
+            </div>
+
+            {idSetupMode === "custom" && (
+              <div className="mt-3">
+                <input
+                  type="text"
+                  value={customUsername}
+                  onChange={(e) => setCustomUsername(e.target.value)}
+                  placeholder={t("usernamePlaceholder")}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-lg text-base focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  disabled={idSetupLoading}
+                />
+              </div>
+            )}
+
+            <div className="mt-4 rounded-lg bg-gray-50 p-3">
+              <p className="text-xs text-gray-600">{t("profileIdHelpText")}</p>
+            </div>
+
+            {idSetupError && (
+              <p className="mt-3 text-xs text-red-600">{idSetupError}</p>
+            )}
+            {idSetupSuccess && (
+              <p className="mt-3 text-xs text-green-600">{idSetupSuccess}</p>
+            )}
+
+            <button
+              type="submit"
+              disabled={idSetupLoading}
+              className="mt-4 w-full rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700 disabled:bg-gray-400 disabled:cursor-not-allowed"
+            >
+              {idSetupLoading ? t("loading") : t("profileIdSetupAction")}
+            </button>
+          </form>
         )}
 
         {/* Analytics Summary */}

--- a/src/app/p/[username]/page.tsx
+++ b/src/app/p/[username]/page.tsx
@@ -6,7 +6,11 @@ import { adminDb } from "@/lib/firebase-admin";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import type { Metadata } from "next";
-import type { DocumentSnapshot } from "firebase-admin/firestore";
+import {
+  FieldPath,
+  type DocumentData,
+  type QueryDocumentSnapshot,
+} from "firebase-admin/firestore";
 import { cache } from "react";
 
 export const revalidate = 300;
@@ -28,53 +32,132 @@ interface UserProfile {
     url: string;
     service?: string;
   }>;
-  profile?: {
-    editorContent?: any;
-    background?: any;
-    socialLinks?: any[];
-  };
 }
 
 interface ProfilePageProps {
   params: { username: string };
 }
 
+const PUBLIC_USER_FIELDS = [
+  "name",
+  "username",
+  "bio",
+  "company",
+  "position",
+  "email",
+  "phone",
+  "website",
+  "address",
+  "photoURL",
+  "links",
+] as const;
+
+type UserProfileDoc = QueryDocumentSnapshot<DocumentData>;
+
+function normalizeUsername(value: string) {
+  return value.trim().toLowerCase();
+}
+
+function toPublicUserProfile(data: DocumentData): UserProfile {
+  return {
+    name: typeof data.name === "string" ? data.name : "",
+    username: typeof data.username === "string" ? data.username : "",
+    bio: typeof data.bio === "string" ? data.bio : "",
+    company: typeof data.company === "string" ? data.company : "",
+    position: typeof data.position === "string" ? data.position : "",
+    email: typeof data.email === "string" ? data.email : "",
+    phone: typeof data.phone === "string" ? data.phone : "",
+    website: typeof data.website === "string" ? data.website : "",
+    address: typeof data.address === "string" ? data.address : "",
+    photoURL: typeof data.photoURL === "string" ? data.photoURL : undefined,
+    links: Array.isArray(data.links) ? data.links : [],
+  };
+}
+
+async function fetchUserByUid(
+  uid: string,
+): Promise<UserProfileDoc | undefined> {
+  const snapshot = await adminDb
+    .collection("users")
+    .where(FieldPath.documentId(), "==", uid)
+    .select(...PUBLIC_USER_FIELDS)
+    .limit(1)
+    .get();
+
+  return snapshot.docs[0];
+}
+
+async function fetchUserByUsername(
+  username: string,
+): Promise<UserProfileDoc | undefined> {
+  const snapshot = await adminDb
+    .collection("users")
+    .where("username", "==", username)
+    .select(...PUBLIC_USER_FIELDS)
+    .limit(1)
+    .get();
+
+  return snapshot.docs[0];
+}
+
+async function resolveUserDoc(
+  username: string,
+): Promise<UserProfileDoc | null> {
+  const normalizedUsername = normalizeUsername(username);
+  const usernameDoc = await adminDb
+    .collection("usernames")
+    .doc(normalizedUsername)
+    .get();
+  const reservedUid = usernameDoc.exists ? usernameDoc.data()?.uid : null;
+
+  if (typeof reservedUid === "string" && reservedUid) {
+    const reservedUserDoc = await fetchUserByUid(reservedUid);
+    if (reservedUserDoc) return reservedUserDoc;
+  }
+
+  const normalizedUserDoc = await fetchUserByUsername(normalizedUsername);
+  if (normalizedUserDoc) return normalizedUserDoc;
+
+  if (username !== normalizedUsername) {
+    const exactUserDoc = await fetchUserByUsername(username);
+    if (exactUserDoc) return exactUserDoc;
+  }
+
+  if (username.startsWith("u_")) {
+    const uidUserDoc = await fetchUserByUid(username.slice(2));
+    if (uidUserDoc) return uidUserDoc;
+  }
+
+  return null;
+}
+
+async function fetchProfileData(userId: string) {
+  const snapshot = await adminDb
+    .collection("users")
+    .doc(userId)
+    .collection("profile")
+    .where(FieldPath.documentId(), "==", "data")
+    .select("components", "background")
+    .limit(1)
+    .get();
+
+  return snapshot.docs[0]?.data() || null;
+}
+
 const fetchUserData = cache(async (username: string) => {
   try {
-    const snapshot = await adminDb
-      .collection("users")
-      .where("username", "==", username)
-      .limit(1)
-      .get();
-
-    let userDoc: DocumentSnapshot | undefined = snapshot.docs[0];
-
-    if (!userDoc && username.startsWith("u_")) {
-      const uid = username.slice(2);
-      const uidDoc = await adminDb.collection("users").doc(uid).get();
-      if (uidDoc.exists) {
-        userDoc = uidDoc;
-      }
-    }
+    const userDoc = await resolveUserDoc(username);
 
     if (!userDoc) {
       return { user: null, profileData: null };
     }
 
-    const userData = userDoc.data() as UserProfile;
+    const userData = toPublicUserProfile(userDoc.data());
     const userId = userDoc.id;
 
     let profileData = null;
     try {
-      const profileDoc = await adminDb
-        .collection("users")
-        .doc(userId)
-        .collection("profile")
-        .doc("data")
-        .get();
-      if (profileDoc.exists) {
-        profileData = profileDoc.data();
-      }
+      profileData = await fetchProfileData(userId);
     } catch (error) {
       console.error(
         "Failed to read profile subdocument for username:",

--- a/src/components/profile/ProfileFloatingActions.tsx
+++ b/src/components/profile/ProfileFloatingActions.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { QRCodeModal } from "@/components/profile/QRCodeModal";
 import { useAuth } from "@/contexts/AuthContext";
 import { useLanguage } from "@/contexts/LanguageContext";
 import { ROUTES, createAuthRedirectUrl } from "@/lib/constants/routes";
 import { Camera, Globe, QrCode } from "lucide-react";
+import dynamic from "next/dynamic";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 
@@ -13,6 +13,12 @@ interface ProfileFloatingActionsProps {
   photoURL?: string;
   variant?: "full" | "minimal";
 }
+
+const QRCodeModal = dynamic(
+  () =>
+    import("@/components/profile/QRCodeModal").then((mod) => mod.QRCodeModal),
+  { ssr: false },
+);
 
 export function ProfileFloatingActions({
   username,
@@ -115,13 +121,15 @@ export function ProfileFloatingActions({
         )}
       </div>
 
-      <QRCodeModal
-        isOpen={showQRCode}
-        onClose={() => setShowQRCode(false)}
-        url={`${origin}/p/${username}`}
-        username={username}
-        logoUrl={photoURL}
-      />
+      {showQRCode && (
+        <QRCodeModal
+          isOpen={showQRCode}
+          onClose={() => setShowQRCode(false)}
+          url={`${origin}/p/${username}`}
+          username={username}
+          logoUrl={photoURL}
+        />
+      )}
     </>
   );
 }

--- a/src/components/profile/SimpleRenderer.tsx
+++ b/src/components/profile/SimpleRenderer.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import React, { memo } from "react";
+import React, { memo, useMemo } from "react";
 import type { ProfileComponent } from "../simple-editor/utils/dataStructure";
 import { SocialLinkButton } from "../simple-editor/SocialLinkButton";
 import { ReadOnlyProfileInfo } from "./ReadOnlyProfileInfo";
 import type { PageBackground } from "./ReadOnlyProfileInfo";
-import { getBackgroundStyle } from "../simple-editor/BackgroundCustomizer";
+import { getBackgroundStyle } from "@/lib/profile/backgroundStyle";
 import Image from "next/image";
 
 // 各コンポーネントタイプの表示コンポーネント（memo化）
@@ -83,7 +83,13 @@ export const SimpleRenderer = memo(function SimpleRenderer({
   background?: PageBackground | null;
 }) {
   // componentsが配列でない場合の対応
-  const safeComponents = Array.isArray(components) ? components : [];
+  const safeComponents = useMemo(
+    () =>
+      Array.isArray(components)
+        ? [...components].sort((a, b) => (a.order || 0) - (b.order || 0))
+        : [],
+    [components],
+  );
 
   return (
     <div className="relative min-h-screen">
@@ -101,44 +107,39 @@ export const SimpleRenderer = memo(function SimpleRenderer({
               <p>プロフィールコンテンツがありません</p>
             </div>
           ) : (
-            safeComponents
-              .sort((a, b) => (a.order || 0) - (b.order || 0))
-              .map((component) => {
-                switch (component.type) {
-                  case "text":
-                    return (
-                      <TextComponent key={component.id} component={component} />
-                    );
-                  case "image":
-                    return (
-                      <ImageComponent
-                        key={component.id}
-                        component={component}
-                      />
-                    );
-                  case "link":
-                    return (
-                      <LinkComponent key={component.id} component={component} />
-                    );
-                  case "profile":
-                    return (
-                      <ProfileComponentView
-                        key={component.id}
-                        component={component}
-                        background={background}
-                      />
-                    );
-                  default:
-                    return (
-                      <div
-                        key={component.id}
-                        className="w-[90%] max-w-[600px] mx-auto bg-red-100 p-4 mb-4 rounded"
-                      >
-                        未対応のコンポーネントタイプ: {component.type}
-                      </div>
-                    );
-                }
-              })
+            safeComponents.map((component) => {
+              switch (component.type) {
+                case "text":
+                  return (
+                    <TextComponent key={component.id} component={component} />
+                  );
+                case "image":
+                  return (
+                    <ImageComponent key={component.id} component={component} />
+                  );
+                case "link":
+                  return (
+                    <LinkComponent key={component.id} component={component} />
+                  );
+                case "profile":
+                  return (
+                    <ProfileComponentView
+                      key={component.id}
+                      component={component}
+                      background={background}
+                    />
+                  );
+                default:
+                  return (
+                    <div
+                      key={component.id}
+                      className="w-[90%] max-w-[600px] mx-auto bg-red-100 p-4 mb-4 rounded"
+                    >
+                      未対応のコンポーネントタイプ: {component.type}
+                    </div>
+                  );
+              }
+            })
           )}
         </div>
       </div>

--- a/src/components/profile/TraditionalProfile.tsx
+++ b/src/components/profile/TraditionalProfile.tsx
@@ -3,9 +3,9 @@
 import { VCardButton } from "@/components/profile/VCardButton";
 import { useLanguage } from "@/contexts/LanguageContext";
 import { QrCode } from "lucide-react";
+import dynamic from "next/dynamic";
 import Image from "next/image";
 import { useState } from "react";
-import { QRCodeModal } from "./QRCodeModal";
 
 interface TraditionalProfileProps {
   user: {
@@ -38,6 +38,11 @@ interface TraditionalProfileProps {
   };
   username: string;
 }
+
+const QRCodeModal = dynamic(
+  () => import("./QRCodeModal").then((mod) => mod.QRCodeModal),
+  { ssr: false },
+);
 
 export function TraditionalProfile({
   user,
@@ -232,13 +237,15 @@ export function TraditionalProfile({
         )}
       </div>
 
-      <QRCodeModal
-        isOpen={showQRCode}
-        onClose={() => setShowQRCode(false)}
-        url={`${origin}/p/${username}`}
-        username={user.username}
-        logoUrl={user.photoURL}
-      />
+      {showQRCode && (
+        <QRCodeModal
+          isOpen={showQRCode}
+          onClose={() => setShowQRCode(false)}
+          url={`${origin}/p/${username}`}
+          username={user.username}
+          logoUrl={user.photoURL}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/simple-editor/BackgroundCustomizer.tsx
+++ b/src/components/simple-editor/BackgroundCustomizer.tsx
@@ -5,6 +5,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { ImageUploader } from "./ImageUploader";
 import { Palette, Sparkles, Image as ImageIcon } from "lucide-react";
 import { useLanguage } from "@/contexts/LanguageContext";
+import { getBackgroundStyle } from "@/lib/profile/backgroundStyle";
 
 interface BackgroundCustomizerProps {
   currentBackground: any;
@@ -276,30 +277,4 @@ export function BackgroundCustomizer({
   );
 }
 
-// 背景スタイル生成関数（export して他のコンポーネントでも使用可能）
-export function getBackgroundStyle(background: any) {
-  if (!background) return {};
-
-  switch (background.type) {
-    case "solid":
-      return { backgroundColor: background.color };
-
-    case "gradient":
-      return {
-        background: `linear-gradient(135deg, ${background.from || "#667eea"}, ${background.to || "#764ba2"})`,
-      };
-
-    case "image":
-      // 不透明度を背景画像に適用するためにlinear-gradientを使用
-      const opacity = background.opacity ?? 0.5;
-      return {
-        backgroundImage: `linear-gradient(rgba(255, 255, 255, ${1 - opacity}), rgba(255, 255, 255, ${1 - opacity})), url(${background.url})`,
-        backgroundSize: "cover",
-        backgroundPosition: "center",
-        backgroundBlendMode: "normal",
-      };
-
-    default:
-      return {};
-  }
-}
+export { getBackgroundStyle };

--- a/src/contexts/LanguageContext.tsx
+++ b/src/contexts/LanguageContext.tsx
@@ -39,6 +39,23 @@ const translations = {
     todayViews: "今日",
     weekViews: "今週",
     language: "言語",
+    recommended: "推奨",
+    profileIdSetupTitle: "公開プロフィールIDを設定",
+    profileIdSetupDescription:
+      "NFCカードやQRコードを発行する前に、公開プロフィールURLに使うIDを決めてください。",
+    profileIdRandomTitle: "ランダムID",
+    profileIdRandomDescription:
+      "推測されにくい数字IDを使います。個人情報をURLに出しにくいため推奨です。",
+    profileIdCustomTitle: "任意ID",
+    profileIdCustomDescription:
+      "名前やブランド名など、覚えやすいIDを自分で設定します。",
+    profileIdUidTitle: "ユーザーID由来の安定ID",
+    profileIdUidDescription:
+      "アカウント固有のIDを使います。任意IDから後で戻すこともできます。",
+    profileIdHelpText:
+      "一度カードやQRコードへURLを書き込んだ後にIDを変えると、旧URLからは同じプロフィールを開けなくなります。",
+    profileIdSetupAction: "このIDで確定",
+    profileIdSetupSuccess: "公開プロフィールIDを設定しました",
 
     // Profile Edit
     profile: "プロフィール",
@@ -157,6 +174,13 @@ const translations = {
       "プロフィールURLをランダムな数字IDに変更します。現在のURLは使えなくなります。続行しますか？",
     randomUsernameUpdated: "プロフィールURLをランダムIDに変更しました",
     randomUsernameUpdateError: "プロフィールURLの変更に失敗しました",
+    profileUrlChangeConfirm:
+      "公開プロフィールURLが変更されます。旧URLを書き込んだNFCカードやQRコードからは、このプロフィールを開けなくなります。続行しますか？",
+    profileUrlChangedWarning:
+      "公開プロフィールURLを変更しました。旧URLを書き込んだNFCカードやQRコードは更新が必要です。",
+    profileIdEditHelp:
+      "任意IDを使った後でも、下のボタンでユーザーID由来の安定IDに戻せます。ID変更後は旧URLを書いたカードやQRコードの更新が必要です。",
+    useUidUsername: "安定IDに戻す",
     profileSaved: "プロフィールを保存しました",
     profileLoadError: "プロフィールの読み込みに失敗しました",
     profileSaveError: "プロフィールの保存に失敗しました",
@@ -390,6 +414,23 @@ const translations = {
     todayViews: "Today",
     weekViews: "This Week",
     language: "Language",
+    recommended: "Recommended",
+    profileIdSetupTitle: "Set Public Profile ID",
+    profileIdSetupDescription:
+      "Choose the ID used in your public profile URL before issuing NFC cards or QR codes.",
+    profileIdRandomTitle: "Random ID",
+    profileIdRandomDescription:
+      "Use a hard-to-guess numeric ID. Recommended because it avoids exposing personal information in the URL.",
+    profileIdCustomTitle: "Custom ID",
+    profileIdCustomDescription:
+      "Set a memorable ID such as your name, handle, or brand.",
+    profileIdUidTitle: "Stable user-ID based ID",
+    profileIdUidDescription:
+      "Use an account-specific stable ID. You can return to it later from a custom ID.",
+    profileIdHelpText:
+      "If you change this ID after writing the URL to a card or QR code, the old URL will no longer open the same profile.",
+    profileIdSetupAction: "Confirm this ID",
+    profileIdSetupSuccess: "Public profile ID has been set",
 
     // Profile Edit
     profile: "Profile",
@@ -507,6 +548,13 @@ const translations = {
       "Change your profile URL to a random numeric ID? Your current URL will stop working.",
     randomUsernameUpdated: "Profile URL changed to a random ID",
     randomUsernameUpdateError: "Failed to change profile URL",
+    profileUrlChangeConfirm:
+      "Your public profile URL will change. NFC cards or QR codes containing the old URL will no longer open this profile. Continue?",
+    profileUrlChangedWarning:
+      "Public profile URL changed. NFC cards or QR codes containing the old URL need to be updated.",
+    profileIdEditHelp:
+      "After using a custom ID, you can return to the stable user-ID based ID with the button below. Changing the ID requires updating cards and QR codes that contain the old URL.",
+    useUidUsername: "Use stable ID",
     profileSaved: "Profile saved successfully",
     profileLoadError: "Failed to load profile",
     profileSaveError: "Failed to save profile",

--- a/src/lib/profile/backgroundStyle.ts
+++ b/src/lib/profile/backgroundStyle.ts
@@ -1,0 +1,40 @@
+import type { CSSProperties } from "react";
+
+interface ProfileBackground {
+  type?: string;
+  color?: string;
+  from?: string;
+  to?: string;
+  opacity?: number;
+  url?: string;
+}
+
+export function getBackgroundStyle(
+  background: ProfileBackground | null | undefined,
+): CSSProperties {
+  if (!background) return {};
+
+  switch (background.type) {
+    case "solid":
+    case "color":
+      return { backgroundColor: background.color };
+
+    case "gradient":
+      return {
+        background: `linear-gradient(135deg, ${background.from || "#667eea"}, ${background.to || "#764ba2"})`,
+      };
+
+    case "image": {
+      const opacity = background.opacity ?? 0.5;
+      return {
+        backgroundImage: `linear-gradient(rgba(255, 255, 255, ${1 - opacity}), rgba(255, 255, 255, ${1 - opacity})), url(${background.url})`,
+        backgroundSize: "cover",
+        backgroundPosition: "center",
+        backgroundBlendMode: "normal",
+      };
+    }
+
+    default:
+      return {};
+  }
+}


### PR DESCRIPTION
## Summary
- add an initial public profile ID setup flow with random ID recommended, custom ID, and stable user-ID based ID options
- warn before profile URL changes because old NFC card and QR URLs will no longer open the same profile
- speed up public profile rendering by resolving reserved usernames through the username map, selecting only required Firestore fields, and moving background style helpers out of the editor bundle
- lazy-load QR code modal dependencies so the public profile initial client bundle is smaller

## Verification
- npm run type-check
- npm run lint
- npm run build

Build result for /p/[username]: 5.66 kB route size, 253 kB First Load JS after optimization.