### PR TITLE
Add profile URL alias redirect controls

### DIFF
--- a/src/app/api/users/me/profile/route.ts
+++ b/src/app/api/users/me/profile/route.ts
@@ -41,6 +41,10 @@ function pickString(value: unknown, maxLength = 200) {
   return typeof value === "string" ? value.slice(0, maxLength) : "";
 }
 
+function normalizeLegacyUrlAction(value: unknown) {
+  return value === "redirect" ? "redirect" : "disable";
+}
+
 async function isUsernameAvailable(username: string, uid: string) {
   const usernameKey = username.toLowerCase();
   const reservation = await adminDb
@@ -48,6 +52,18 @@ async function isUsernameAvailable(username: string, uid: string) {
     .doc(usernameKey)
     .get();
   if (reservation.exists && reservation.data()?.uid !== uid) {
+    return false;
+  }
+
+  const alias = await adminDb
+    .collection("usernameAliases")
+    .doc(usernameKey)
+    .get();
+  if (
+    alias.exists &&
+    alias.data()?.status === "redirect" &&
+    alias.data()?.uid !== uid
+  ) {
     return false;
   }
 
@@ -111,6 +127,7 @@ export async function PATCH(request: NextRequest) {
     }
 
     const body = await request.json();
+    const legacyUrlAction = normalizeLegacyUrlAction(body.legacyUrlAction);
     const usernameMode =
       typeof body.usernameMode === "string" ? body.usernameMode : "custom";
     const requestedUsername =
@@ -221,9 +238,31 @@ export async function PATCH(request: NextRequest) {
         ) {
           transaction.delete(previousRef);
         }
+
+        const previousAliasRef = adminDb
+          .collection("usernameAliases")
+          .doc(previousUsername.toLowerCase());
+        if (legacyUrlAction === "redirect") {
+          transaction.set(previousAliasRef, {
+            uid: verification.uid,
+            username: previousUsername,
+            targetUsername: requestedUsername,
+            status: "redirect",
+            updatedAt: FieldValue.serverTimestamp(),
+            createdAt: FieldValue.serverTimestamp(),
+          });
+        } else {
+          transaction.delete(previousAliasRef);
+        }
+
         profileUpdates.previousUsernames =
           FieldValue.arrayUnion(previousUsername);
       }
+
+      const requestedAliasRef = adminDb
+        .collection("usernameAliases")
+        .doc(requestedUsername.toLowerCase());
+      transaction.delete(requestedAliasRef);
 
       transaction.set(usernameRef, {
         uid: verification.uid,

--- a/src/app/api/users/me/rotate-username/route.ts
+++ b/src/app/api/users/me/rotate-username/route.ts
@@ -3,6 +3,10 @@ import { generateDefaultUsername } from "@/lib/username";
 import { FieldValue } from "firebase-admin/firestore";
 import { NextRequest, NextResponse } from "next/server";
 
+function normalizeLegacyUrlAction(value: unknown) {
+  return value === "redirect" ? "redirect" : "disable";
+}
+
 async function generateUniqueUsername() {
   for (let attempt = 0; attempt < 8; attempt += 1) {
     const username = generateDefaultUsername();
@@ -44,6 +48,12 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
+    let body: Record<string, unknown> = {};
+    try {
+      body = await request.json();
+    } catch {}
+    const legacyUrlAction = normalizeLegacyUrlAction(body.legacyUrlAction);
+
     const userRef = adminDb.collection("users").doc(verification.uid);
     const username = await generateUniqueUsername();
     const result = await adminDb.runTransaction(async (transaction) => {
@@ -78,7 +88,28 @@ export async function POST(request: NextRequest) {
         ) {
           transaction.delete(previousRef);
         }
+
+        const previousAliasRef = adminDb
+          .collection("usernameAliases")
+          .doc(String(previousUsername).toLowerCase());
+        if (legacyUrlAction === "redirect") {
+          transaction.set(previousAliasRef, {
+            uid: verification.uid,
+            username: previousUsername,
+            targetUsername: username,
+            status: "redirect",
+            updatedAt: FieldValue.serverTimestamp(),
+            createdAt: FieldValue.serverTimestamp(),
+          });
+        } else {
+          transaction.delete(previousAliasRef);
+        }
       }
+
+      const requestedAliasRef = adminDb
+        .collection("usernameAliases")
+        .doc(username.toLowerCase());
+      transaction.delete(requestedAliasRef);
 
       transaction.set(usernameRef, {
         uid: verification.uid,

--- a/src/app/api/users/me/username-aliases/route.ts
+++ b/src/app/api/users/me/username-aliases/route.ts
@@ -1,0 +1,187 @@
+import { adminDb, verifyIdToken } from "@/lib/firebase-admin";
+import { FieldValue, type DocumentData } from "firebase-admin/firestore";
+import { NextRequest, NextResponse } from "next/server";
+
+function normalizeUsername(value: unknown) {
+  return typeof value === "string" ? value.trim().toLowerCase() : "";
+}
+
+function isValidLegacyAlias(username: string) {
+  return (
+    username.length >= 3 && username.length <= 150 && !username.includes("/")
+  );
+}
+
+function normalizeAction(value: unknown) {
+  return value === "redirect" ? "redirect" : "disable";
+}
+
+async function verifyRequest(request: NextRequest) {
+  const authHeader = request.headers.get("authorization");
+  const token = authHeader?.startsWith("Bearer ")
+    ? authHeader.slice("Bearer ".length)
+    : null;
+
+  if (!token) return null;
+
+  const verification = await verifyIdToken(token);
+  return verification.success && verification.uid ? verification.uid : null;
+}
+
+function getPreviousUsernames(data: DocumentData | undefined) {
+  const previous = Array.isArray(data?.previousUsernames)
+    ? data?.previousUsernames
+    : [];
+  const current = normalizeUsername(data?.username);
+  return Array.from(
+    new Set(
+      previous
+        .map(normalizeUsername)
+        .filter((username) => username && username !== current),
+    ),
+  );
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const uid = await verifyRequest(request);
+    if (!uid) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const userDoc = await adminDb.collection("users").doc(uid).get();
+    if (!userDoc.exists) {
+      return NextResponse.json({ error: "User not found" }, { status: 404 });
+    }
+
+    const data = userDoc.data();
+    const currentUsername = normalizeUsername(data?.username);
+    const previousUsernames = getPreviousUsernames(data);
+
+    if (previousUsernames.length === 0) {
+      return NextResponse.json({
+        currentUsername,
+        aliases: [],
+      });
+    }
+
+    const aliasRefs = previousUsernames.map((username) =>
+      adminDb.collection("usernameAliases").doc(username),
+    );
+    const aliasDocs = await adminDb.getAll(...aliasRefs);
+    const aliases = previousUsernames.map((username, index) => {
+      const alias = aliasDocs[index];
+      const aliasData = alias.exists ? alias.data() : null;
+      const isRedirecting =
+        aliasData?.uid === uid && aliasData?.status === "redirect";
+
+      return {
+        username,
+        status: isRedirecting ? "redirect" : "disabled",
+        targetUsername: isRedirecting
+          ? aliasData?.targetUsername || currentUsername
+          : currentUsername,
+      };
+    });
+
+    return NextResponse.json({
+      currentUsername,
+      aliases,
+    });
+  } catch (error) {
+    console.error("Failed to fetch username aliases:", error);
+    return NextResponse.json(
+      { error: "username_alias_fetch_failed" },
+      { status: 500 },
+    );
+  }
+}
+
+export async function PATCH(request: NextRequest) {
+  try {
+    const uid = await verifyRequest(request);
+    if (!uid) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const body = await request.json();
+    const aliasUsername = normalizeUsername(body.aliasUsername);
+    const action = normalizeAction(body.action);
+
+    if (!isValidLegacyAlias(aliasUsername)) {
+      return NextResponse.json({ error: "username_invalid" }, { status: 400 });
+    }
+
+    const userRef = adminDb.collection("users").doc(uid);
+    const result = await adminDb.runTransaction(async (transaction) => {
+      const userDoc = await transaction.get(userRef);
+      if (!userDoc.exists) {
+        return null;
+      }
+
+      const userData = userDoc.data();
+      const currentUsername = normalizeUsername(userData?.username);
+      const previousUsernames = getPreviousUsernames(userData);
+
+      if (
+        aliasUsername === currentUsername ||
+        !previousUsernames.includes(aliasUsername)
+      ) {
+        throw new Error("ALIAS_NOT_ALLOWED");
+      }
+
+      const usernameRef = adminDb.collection("usernames").doc(aliasUsername);
+      const usernameDoc = await transaction.get(usernameRef);
+      if (usernameDoc.exists && usernameDoc.data()?.uid !== uid) {
+        throw new Error("ALIAS_TAKEN");
+      }
+
+      const aliasRef = adminDb.collection("usernameAliases").doc(aliasUsername);
+      const aliasDoc = await transaction.get(aliasRef);
+      if (aliasDoc.exists && aliasDoc.data()?.uid !== uid) {
+        throw new Error("ALIAS_TAKEN");
+      }
+
+      if (action === "redirect") {
+        transaction.set(aliasRef, {
+          uid,
+          username: aliasUsername,
+          targetUsername: currentUsername,
+          status: "redirect",
+          updatedAt: FieldValue.serverTimestamp(),
+          createdAt: aliasDoc.exists
+            ? aliasDoc.data()?.createdAt || FieldValue.serverTimestamp()
+            : FieldValue.serverTimestamp(),
+        });
+      } else {
+        transaction.delete(aliasRef);
+      }
+
+      return {
+        username: aliasUsername,
+        status: action === "redirect" ? "redirect" : "disabled",
+        targetUsername: currentUsername,
+      };
+    });
+
+    if (!result) {
+      return NextResponse.json({ error: "User not found" }, { status: 404 });
+    }
+
+    return NextResponse.json({ alias: result });
+  } catch (error) {
+    if (error instanceof Error && error.message === "ALIAS_TAKEN") {
+      return NextResponse.json({ error: "username_taken" }, { status: 409 });
+    }
+
+    if (error instanceof Error && error.message === "ALIAS_NOT_ALLOWED") {
+      return NextResponse.json({ error: "alias_not_allowed" }, { status: 400 });
+    }
+
+    console.error("Failed to update username alias:", error);
+    return NextResponse.json(
+      { error: "username_alias_update_failed" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/dashboard/edit/page.tsx
+++ b/src/app/dashboard/edit/page.tsx
@@ -42,6 +42,14 @@ interface ProfileData {
   photoURL: string;
 }
 
+type LegacyUrlAction = "redirect" | "disable";
+
+interface UsernameAlias {
+  username: string;
+  status: "redirect" | "disabled";
+  targetUsername: string;
+}
+
 export default function EditProfilePage() {
   const { user, loading, getIdToken } = useAuth();
   const router = useRouter();
@@ -49,8 +57,12 @@ export default function EditProfilePage() {
   const [isLoading, setIsLoading] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
   const [isRotatingUsername, setIsRotatingUsername] = useState(false);
+  const [isUpdatingAlias, setIsUpdatingAlias] = useState<string | null>(null);
   const [usernameSuggestions, setUsernameSuggestions] = useState<string[]>([]);
   const [originalUsername, setOriginalUsername] = useState("");
+  const [legacyUrlAction, setLegacyUrlAction] =
+    useState<LegacyUrlAction>("redirect");
+  const [usernameAliases, setUsernameAliases] = useState<UsernameAlias[]>([]);
   const [profile, setProfile] = useState<ProfileData>({
     name: "",
     username: "",
@@ -144,13 +156,35 @@ export default function EditProfilePage() {
     }
   }, [user, t]);
 
+  const loadUsernameAliases = useCallback(async () => {
+    if (!user) return;
+
+    try {
+      const token = await getIdToken();
+      if (!token) return;
+
+      const response = await fetch("/api/users/me/username-aliases", {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      });
+      if (!response.ok) return;
+
+      const data = await response.json();
+      setUsernameAliases(Array.isArray(data.aliases) ? data.aliases : []);
+    } catch (error) {
+      console.error("Error loading username aliases:", error);
+    }
+  }, [user, getIdToken]);
+
   useEffect(() => {
     if (!loading && !user) {
       router.push("/signin");
     } else if (user) {
       loadProfile();
+      loadUsernameAliases();
     }
-  }, [user, loading, router, loadProfile]);
+  }, [user, loading, router, loadProfile, loadUsernameAliases]);
 
   const handleInputChange = (field: keyof ProfileData, value: string) => {
     if (field === "username") {
@@ -196,7 +230,10 @@ export default function EditProfilePage() {
           Authorization: `Bearer ${token}`,
           "Content-Type": "application/json",
         },
-        body: JSON.stringify(profile),
+        body: JSON.stringify({
+          ...profile,
+          legacyUrlAction,
+        }),
       });
 
       const data = await response.json();
@@ -271,9 +308,12 @@ export default function EditProfilePage() {
       toast({
         title: t("success"),
         description: usernameChanged
-          ? t("profileUrlChangedWarning")
+          ? legacyUrlAction === "redirect"
+            ? t("profileUrlChangedRedirecting")
+            : t("profileUrlChangedWarning")
           : t("profileSaved"),
       });
+      await loadUsernameAliases();
 
       router.push("/dashboard");
     } catch (error) {
@@ -305,7 +345,9 @@ export default function EditProfilePage() {
         method: "POST",
         headers: {
           Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
         },
+        body: JSON.stringify({ legacyUrlAction }),
       });
 
       const data = await response.json();
@@ -318,8 +360,12 @@ export default function EditProfilePage() {
       setUsernameSuggestions([]);
       toast({
         title: t("success"),
-        description: t("profileUrlChangedWarning"),
+        description:
+          legacyUrlAction === "redirect"
+            ? t("profileUrlChangedRedirecting")
+            : t("profileUrlChangedWarning"),
       });
+      await loadUsernameAliases();
     } catch (error) {
       console.error("Error rotating username:", error);
       toast({
@@ -329,6 +375,57 @@ export default function EditProfilePage() {
       });
     } finally {
       setIsRotatingUsername(false);
+    }
+  };
+
+  const handleAliasUpdate = async (
+    aliasUsername: string,
+    action: LegacyUrlAction,
+  ) => {
+    if (!user || isUpdatingAlias) return;
+
+    setIsUpdatingAlias(aliasUsername);
+    try {
+      const token = await getIdToken();
+      if (!token) {
+        throw new Error("Missing ID token");
+      }
+
+      const response = await fetch("/api/users/me/username-aliases", {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ aliasUsername, action }),
+      });
+
+      const data = await response.json();
+      if (!response.ok) {
+        throw new Error(data.error || "Failed to update username alias");
+      }
+
+      setUsernameAliases((prev) =>
+        prev.map((alias) =>
+          alias.username === data.alias.username ? data.alias : alias,
+        ),
+      );
+      toast({
+        title: t("success"),
+        description:
+          action === "redirect"
+            ? t("legacyUrlRedirectEnabled")
+            : t("legacyUrlDisabled"),
+      });
+    } catch (error) {
+      console.error("Error updating username alias:", error);
+      toast({
+        title: t("error"),
+        description: t("legacyUrlUpdateError"),
+        variant: "destructive",
+      });
+    } finally {
+      setIsUpdatingAlias(null);
     }
   };
 
@@ -420,6 +517,49 @@ export default function EditProfilePage() {
                     </Button>
                   </div>
                 )}
+                <div className="rounded-md border border-gray-200 bg-gray-50 p-3">
+                  <p className="text-xs font-medium text-gray-900">
+                    {t("legacyUrlHandlingTitle")}
+                  </p>
+                  <div className="mt-2 space-y-2">
+                    <label className="flex cursor-pointer gap-2 rounded-md bg-white p-2 text-xs text-gray-700">
+                      <input
+                        type="radio"
+                        name="legacy-url-action"
+                        value="redirect"
+                        checked={legacyUrlAction === "redirect"}
+                        onChange={() => setLegacyUrlAction("redirect")}
+                        className="mt-0.5"
+                      />
+                      <span>
+                        <span className="font-medium text-gray-900">
+                          {t("legacyUrlRedirectChoice")}
+                        </span>
+                        <span className="block text-gray-600">
+                          {t("legacyUrlRedirectHelp")}
+                        </span>
+                      </span>
+                    </label>
+                    <label className="flex cursor-pointer gap-2 rounded-md bg-white p-2 text-xs text-gray-700">
+                      <input
+                        type="radio"
+                        name="legacy-url-action"
+                        value="disable"
+                        checked={legacyUrlAction === "disable"}
+                        onChange={() => setLegacyUrlAction("disable")}
+                        className="mt-0.5"
+                      />
+                      <span>
+                        <span className="font-medium text-gray-900">
+                          {t("legacyUrlDisableChoice")}
+                        </span>
+                        <span className="block text-gray-600">
+                          {t("legacyUrlDisableHelp")}
+                        </span>
+                      </span>
+                    </label>
+                  </div>
+                </div>
                 <p className="text-xs text-muted-foreground">
                   {t("profileUrlPrefix")}: /p/{profile.username || "username"}
                 </p>
@@ -541,6 +681,72 @@ export default function EditProfilePage() {
             </div>
           </CardContent>
         </Card>
+
+        {usernameAliases.length > 0 && (
+          <Card>
+            <CardHeader>
+              <CardTitle>{t("legacyUrlManagementTitle")}</CardTitle>
+              <CardDescription>
+                {t("legacyUrlManagementDescription")}
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              {usernameAliases.map((alias) => (
+                <div
+                  key={alias.username}
+                  className="rounded-lg border border-gray-200 p-3"
+                >
+                  <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                    <div>
+                      <p className="text-sm font-medium text-gray-900">
+                        /p/{alias.username}
+                      </p>
+                      <p className="text-xs text-muted-foreground">
+                        {alias.status === "redirect"
+                          ? t("legacyUrlRedirectingTo").replace(
+                              "{username}",
+                              alias.targetUsername,
+                            )
+                          : t("legacyUrlCurrentlyDisabled")}
+                      </p>
+                    </div>
+                    <div className="flex gap-2">
+                      <Button
+                        type="button"
+                        variant={
+                          alias.status === "redirect" ? "default" : "outline"
+                        }
+                        size="sm"
+                        disabled={isUpdatingAlias === alias.username}
+                        onClick={() =>
+                          handleAliasUpdate(alias.username, "redirect")
+                        }
+                      >
+                        {isUpdatingAlias === alias.username ? (
+                          <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                        ) : null}
+                        {t("enableRedirect")}
+                      </Button>
+                      <Button
+                        type="button"
+                        variant={
+                          alias.status === "disabled" ? "default" : "outline"
+                        }
+                        size="sm"
+                        disabled={isUpdatingAlias === alias.username}
+                        onClick={() =>
+                          handleAliasUpdate(alias.username, "disable")
+                        }
+                      >
+                        {t("disableRedirect")}
+                      </Button>
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </CardContent>
+          </Card>
+        )}
 
         <Card>
           <CardHeader>

--- a/src/app/p/[username]/page.tsx
+++ b/src/app/p/[username]/page.tsx
@@ -4,7 +4,7 @@ import { SimpleRenderer } from "@/components/profile/SimpleRenderer";
 import { TraditionalProfile } from "@/components/profile/TraditionalProfile";
 import { adminDb } from "@/lib/firebase-admin";
 import Link from "next/link";
-import { notFound } from "next/navigation";
+import { notFound, redirect } from "next/navigation";
 import type { Metadata } from "next";
 import {
   FieldPath,
@@ -54,6 +54,11 @@ const PUBLIC_USER_FIELDS = [
 
 type UserProfileDoc = QueryDocumentSnapshot<DocumentData>;
 
+interface ResolvedUserDoc {
+  userDoc: UserProfileDoc;
+  redirectUsername?: string;
+}
+
 function normalizeUsername(value: string) {
   return value.trim().toLowerCase();
 }
@@ -102,7 +107,7 @@ async function fetchUserByUsername(
 
 async function resolveUserDoc(
   username: string,
-): Promise<UserProfileDoc | null> {
+): Promise<ResolvedUserDoc | null> {
   const normalizedUsername = normalizeUsername(username);
   const usernameDoc = await adminDb
     .collection("usernames")
@@ -112,20 +117,40 @@ async function resolveUserDoc(
 
   if (typeof reservedUid === "string" && reservedUid) {
     const reservedUserDoc = await fetchUserByUid(reservedUid);
-    if (reservedUserDoc) return reservedUserDoc;
+    if (reservedUserDoc) return { userDoc: reservedUserDoc };
   }
 
   const normalizedUserDoc = await fetchUserByUsername(normalizedUsername);
-  if (normalizedUserDoc) return normalizedUserDoc;
+  if (normalizedUserDoc) return { userDoc: normalizedUserDoc };
 
   if (username !== normalizedUsername) {
     const exactUserDoc = await fetchUserByUsername(username);
-    if (exactUserDoc) return exactUserDoc;
+    if (exactUserDoc) return { userDoc: exactUserDoc };
+  }
+
+  const aliasDoc = await adminDb
+    .collection("usernameAliases")
+    .doc(normalizedUsername)
+    .get();
+  const aliasData = aliasDoc.exists ? aliasDoc.data() : null;
+  const aliasUid = aliasData?.status === "redirect" ? aliasData?.uid : null;
+  if (typeof aliasUid === "string" && aliasUid) {
+    const aliasUserDoc = await fetchUserByUid(aliasUid);
+    if (aliasUserDoc) {
+      const currentUsername = normalizeUsername(aliasUserDoc.data().username);
+      return {
+        userDoc: aliasUserDoc,
+        redirectUsername:
+          currentUsername && currentUsername !== normalizedUsername
+            ? currentUsername
+            : undefined,
+      };
+    }
   }
 
   if (username.startsWith("u_")) {
     const uidUserDoc = await fetchUserByUid(username.slice(2));
-    if (uidUserDoc) return uidUserDoc;
+    if (uidUserDoc) return { userDoc: uidUserDoc };
   }
 
   return null;
@@ -146,12 +171,13 @@ async function fetchProfileData(userId: string) {
 
 const fetchUserData = cache(async (username: string) => {
   try {
-    const userDoc = await resolveUserDoc(username);
+    const resolved = await resolveUserDoc(username);
 
-    if (!userDoc) {
-      return { user: null, profileData: null };
+    if (!resolved) {
+      return { user: null, profileData: null, redirectUsername: null };
     }
 
+    const { userDoc, redirectUsername } = resolved;
     const userData = toPublicUserProfile(userDoc.data());
     const userId = userDoc.id;
 
@@ -166,7 +192,7 @@ const fetchUserData = cache(async (username: string) => {
       );
     }
 
-    return { user: userData, profileData };
+    return { user: userData, profileData, redirectUsername };
   } catch (error) {
     console.error("Failed to fetch user data for username:", username, error);
     throw error;
@@ -226,12 +252,19 @@ function Footer() {
 }
 
 export default async function ProfilePage({ params }: ProfilePageProps) {
-  const { user, profileData } = await fetchUserData(params.username);
+  const { user, profileData, redirectUsername } = await fetchUserData(
+    params.username,
+  );
 
   if (!user) {
     notFound();
   }
 
+  if (redirectUsername) {
+    redirect(`/p/${redirectUsername}`);
+  }
+
+  const publicUsername = user.username || params.username;
   const nameParts = user.name?.split(" ") || [];
   const vcardFirstName = nameParts[0] || "";
   const vcardLastName =
@@ -256,11 +289,11 @@ export default async function ProfilePage({ params }: ProfilePageProps) {
           background={profileData.background}
         />
         <ProfileFloatingActions
-          username={params.username}
+          username={publicUsername}
           photoURL={user.photoURL}
           variant="full"
         />
-        <ProfileAnalyticsTracker username={params.username} />
+        <ProfileAnalyticsTracker username={publicUsername} />
         <Footer />
       </>
     );
@@ -271,14 +304,14 @@ export default async function ProfilePage({ params }: ProfilePageProps) {
       <TraditionalProfile
         user={user}
         vcardData={vcardData}
-        username={params.username}
+        username={publicUsername}
       />
       <ProfileFloatingActions
-        username={params.username}
+        username={publicUsername}
         photoURL={user.photoURL}
         variant="minimal"
       />
-      <ProfileAnalyticsTracker username={params.username} />
+      <ProfileAnalyticsTracker username={publicUsername} />
       <Footer />
     </>
   );

--- a/src/contexts/LanguageContext.tsx
+++ b/src/contexts/LanguageContext.tsx
@@ -175,12 +175,31 @@ const translations = {
     randomUsernameUpdated: "プロフィールURLをランダムIDに変更しました",
     randomUsernameUpdateError: "プロフィールURLの変更に失敗しました",
     profileUrlChangeConfirm:
-      "公開プロフィールURLが変更されます。旧URLを書き込んだNFCカードやQRコードからは、このプロフィールを開けなくなります。続行しますか？",
+      "公開プロフィールURLが変更されます。選択した旧URLの扱いで続行しますか？",
     profileUrlChangedWarning:
       "公開プロフィールURLを変更しました。旧URLを書き込んだNFCカードやQRコードは更新が必要です。",
+    profileUrlChangedRedirecting:
+      "公開プロフィールURLを変更しました。旧URLは新しいURLへ転送されます。",
     profileIdEditHelp:
-      "任意IDを使った後でも、下のボタンでユーザーID由来の安定IDに戻せます。ID変更後は旧URLを書いたカードやQRコードの更新が必要です。",
+      "任意IDを使った後でも、下のボタンでユーザーID由来の安定IDに戻せます。ID変更時は旧URLを転送するか無効化するかを選べます。",
     useUidUsername: "安定IDに戻す",
+    legacyUrlHandlingTitle: "ID変更時の旧URLの扱い",
+    legacyUrlRedirectChoice: "旧URLを新しいURLへ転送する",
+    legacyUrlRedirectHelp:
+      "NFCカードやQRコードを更新せずに使い続けられます。旧URLを知っている人は新しいプロフィールへアクセスできます。",
+    legacyUrlDisableChoice: "旧URLを無効化する",
+    legacyUrlDisableHelp:
+      "メール由来IDなどを隠したい場合はこちらを選んでください。旧URLを書いたカードやQRコードは更新が必要です。",
+    legacyUrlManagementTitle: "過去のプロフィールURL",
+    legacyUrlManagementDescription:
+      "以前使っていたIDを、現在のプロフィールURLへ転送するか無効化するかを後から変更できます。",
+    legacyUrlRedirectingTo: "現在 /p/{username} へ転送中",
+    legacyUrlCurrentlyDisabled: "現在は無効です",
+    enableRedirect: "転送する",
+    disableRedirect: "無効化",
+    legacyUrlRedirectEnabled: "旧URLの転送を有効にしました",
+    legacyUrlDisabled: "旧URLを無効化しました",
+    legacyUrlUpdateError: "旧URL設定の更新に失敗しました",
     profileSaved: "プロフィールを保存しました",
     profileLoadError: "プロフィールの読み込みに失敗しました",
     profileSaveError: "プロフィールの保存に失敗しました",
@@ -549,12 +568,31 @@ const translations = {
     randomUsernameUpdated: "Profile URL changed to a random ID",
     randomUsernameUpdateError: "Failed to change profile URL",
     profileUrlChangeConfirm:
-      "Your public profile URL will change. NFC cards or QR codes containing the old URL will no longer open this profile. Continue?",
+      "Your public profile URL will change. Continue with the selected old URL handling?",
     profileUrlChangedWarning:
       "Public profile URL changed. NFC cards or QR codes containing the old URL need to be updated.",
+    profileUrlChangedRedirecting:
+      "Public profile URL changed. The old URL now redirects to the new URL.",
     profileIdEditHelp:
-      "After using a custom ID, you can return to the stable user-ID based ID with the button below. Changing the ID requires updating cards and QR codes that contain the old URL.",
+      "After using a custom ID, you can return to the stable user-ID based ID with the button below. When changing the ID, choose whether old URLs redirect or stay disabled.",
     useUidUsername: "Use stable ID",
+    legacyUrlHandlingTitle: "Old URL handling when ID changes",
+    legacyUrlRedirectChoice: "Redirect old URL to the new URL",
+    legacyUrlRedirectHelp:
+      "NFC cards and QR codes can keep working. Anyone who knows the old URL can still reach the new profile.",
+    legacyUrlDisableChoice: "Disable old URL",
+    legacyUrlDisableHelp:
+      "Choose this if you want to hide an email-derived ID. Cards and QR codes using the old URL need to be updated.",
+    legacyUrlManagementTitle: "Previous profile URLs",
+    legacyUrlManagementDescription:
+      "You can later change whether previous IDs redirect to the current profile URL or stay disabled.",
+    legacyUrlRedirectingTo: "Redirecting to /p/{username}",
+    legacyUrlCurrentlyDisabled: "Currently disabled",
+    enableRedirect: "Redirect",
+    disableRedirect: "Disable",
+    legacyUrlRedirectEnabled: "Old URL redirect enabled",
+    legacyUrlDisabled: "Old URL disabled",
+    legacyUrlUpdateError: "Failed to update old URL setting",
     profileSaved: "Profile saved successfully",
     profileLoadError: "Failed to load profile",
     profileSaveError: "Failed to save profile",


### PR DESCRIPTION
## Summary
- add usernameAliases support so previous profile IDs can redirect to the current public profile ID
- allow users to choose old URL handling when changing profile IDs: redirect or disable
- add a previous URL management section so already-changed IDs can be re-enabled for redirect later
- update /p/[username] to redirect active legacy aliases to the current canonical profile URL

## Verification
- npm run type-check
- npm run lint
- npm run build

## Notes
- Default API behavior remains disable unless the client explicitly sends legacyUrlAction=redirect.
- Legacy aliases allow old IDs with characters like @ or . so older email-derived IDs can be restored as redirects.