### PR TITLE
[codex] Preserve profile photo during ID setup

### DIFF
--- a/src/app/api/users/me/profile/route.ts
+++ b/src/app/api/users/me/profile/route.ts
@@ -143,9 +143,10 @@ export async function PATCH(request: NextRequest) {
 
     const userRef = adminDb.collection("users").doc(verification.uid);
     const userDoc = await userRef.get();
+    const existingUserData = userDoc.exists ? userDoc.data() || {} : {};
     const currentUsernameRaw =
-      typeof userDoc.data()?.username === "string"
-        ? userDoc.data()?.username
+      typeof existingUserData.username === "string"
+        ? existingUserData.username
         : "";
     const currentUsername = normalizeUsername(currentUsernameRaw);
     const isUsernameChanging = requestedUsername !== currentUsername;
@@ -181,10 +182,20 @@ export async function PATCH(request: NextRequest) {
     };
 
     for (const field of PROFILE_STRING_FIELDS) {
-      profileUpdates[field] = pickString(
+      const pickedValue = pickString(
         body[field],
         field === "bio" ? BIO_MAX_LENGTH : 200,
       );
+
+      if (field === "photoURL" && !pickedValue) {
+        profileUpdates[field] =
+          typeof existingUserData.photoURL === "string"
+            ? existingUserData.photoURL
+            : "";
+        continue;
+      }
+
+      profileUpdates[field] = pickedValue;
     }
 
     await adminDb.runTransaction(async (transaction) => {

--- a/src/app/dashboard/edit/page.tsx
+++ b/src/app/dashboard/edit/page.tsx
@@ -127,9 +127,14 @@ export default function EditProfilePage() {
         phone: userData?.phone || "",
         website: userData?.website || "",
         address: userData?.address || "",
-        photoURL: userData?.photoURL || "",
+        photoURL: userData?.photoURL || user.photoURL || "",
       };
-      const src = hasComponentData ? fromComponent : fallback;
+      const componentOverrides = Object.fromEntries(
+        Object.entries(fromComponent).filter(([, value]) => value !== ""),
+      );
+      const src = hasComponentData
+        ? { ...fallback, ...componentOverrides }
+        : fallback;
 
       setProfile({
         name: src.name || user.displayName || "",

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -161,7 +161,7 @@ export default function DashboardPage() {
           phone: userProfile?.phone || "",
           website: userProfile?.website || "",
           address: userProfile?.address || "",
-          photoURL: userProfile?.photoURL || "",
+          ...(userProfile?.photoURL ? { photoURL: userProfile.photoURL } : {}),
         }),
       });
 

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -125,7 +125,6 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
         email: user.email,
         emailVerified: user.emailVerified,
         displayName: user.displayName,
-        photoURL: user.photoURL,
         updatedAt: serverTimestamp(),
       };
 
@@ -133,6 +132,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
         // 新規ユーザーの場合
         await setDoc(userRef, {
           ...userData,
+          photoURL: user.photoURL,
           username: generateDefaultUsername(),
           createdAt: serverTimestamp(),
           name: user.displayName || "",
@@ -157,6 +157,9 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
           userRef,
           {
             ...userData,
+            ...(!existingData.photoURL && user.photoURL
+              ? { photoURL: user.photoURL }
+              : {}),
             ...(!existingData.username
               ? { username: getUidFallbackUsername(user.uid) }
               : {}),


### PR DESCRIPTION
## Summary
- Preserve an existing `photoURL` when profile ID setup or profile save submits an empty photo value.
- Stop the dashboard ID setup flow from sending an empty `photoURL` when it has no photo data.
- Merge profile component data with user fallback data in the edit screen so a component missing only `photoURL` does not erase the saved photo.
- Stop auth-state sync from overwriting an existing profile photo with the Firebase Auth provider photo on every login/session refresh.

## Root cause
There were two destructive paths around `photoURL`:

1. The fixed-ID confirmation flow reused the profile update endpoint and sent `photoURL: ""` when the dashboard state did not contain a photo URL. The API treated that empty string as authoritative and overwrote the existing Firestore `users/{uid}.photoURL`.
2. Existing-user auth sync always wrote Firebase Auth's `user.photoURL` back into the user document. That could replace a profile-managed uploaded photo just by loading an authenticated dashboard/edit screen.

The edit page could also amplify the issue by preferring partially populated profile component data over the user document fallback.

## Validation
- `npm run type-check`
- `npm run lint`
- `npm run build`